### PR TITLE
fix:keep footer on bottom at contribution page

### DIFF
--- a/style.css
+++ b/style.css
@@ -62,7 +62,15 @@ body.eightgon-page {
 .content {
     position: relative;
     z-index: 1;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
+.footer {
+    margin-top: auto;
+}
+
+
 
 #three-canvas {
     width: 100%;


### PR DESCRIPTION
Closes #12 

### What was changed
- Fixed an issue where the footer on the Contributions page did not stick to the bottom of the viewport when the page content was short.
- Updated the layout to ensure consistent footer positioning across screen sizes.

### How it was tested
- Tested on desktop browser
- Tested using mobile view (Chrome DevTools)

### Screenshots
**Desktop View**
<img width="1351" height="684" alt="Screenshot 2026-01-01 194555" src="https://github.com/user-attachments/assets/3eb0d79a-d352-455f-9ad8-96e08bfdc1bd" />

**Mobile View**
<img width="420" height="547" alt="Screenshot 2026-01-01 194713" src="https://github.com/user-attachments/assets/6472d32a-92c1-43a1-93a8-78150d3817ef" />

