### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,98 @@
+
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of **Xaytheon** pledge to make participation in our project and community a **harassment-free, inclusive, and welcoming experience for everyone**, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+This Code of Conduct applies to all project spaces, including GitHub, Discord, and any other official communication channels.
+
+---
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Being respectful, considerate, and professional
+- Welcoming new contributors and helping them learn
+- Giving and accepting constructive feedback
+- Respecting differing viewpoints and experiences
+- Focusing on what is best for the community and project
+
+Examples of unacceptable behavior include:
+
+- Harassment, discrimination, or hate speech
+- Personal attacks, insults, or derogatory comments
+- Trolling, spamming, or low-effort disruptive behavior
+- Publishing others’ private information without permission
+- Any behavior that would reasonably make others feel unsafe or unwelcome
+
+---
+
+## Scope
+
+This Code of Conduct applies within all project spaces, including but not limited to:
+
+- GitHub repositories, issues, pull requests, and discussions
+- Discord servers used for project coordination
+- Public or private communication related to the project
+- Any situation where an individual represents the Xaytheon community
+
+---
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing the standards of acceptable behavior.
+
+Maintainers have the right and responsibility to:
+- Remove, edit, or reject comments, commits, code, issues, or pull requests that violate this Code of Conduct
+- Temporarily or permanently ban contributors who engage in unacceptable behavior
+- Take appropriate action to maintain a safe and respectful environment
+
+---
+
+## Reporting Guidelines
+
+If you experience or witness behavior that violates this Code of Conduct, please report it promptly.
+
+### How to Report
+- Contact the maintainers directly via GitHub or Discord
+- Provide as much relevant information as possible, including:
+  - Description of the incident
+  - Links, screenshots, or message references (if applicable)
+  - Any other context that may help
+
+All reports will be handled **confidentially** and reviewed fairly.
+
+---
+
+## Enforcement Process
+
+Maintainers will:
+1. Review the report
+2. Assess the situation based on context and severity
+3. Decide on appropriate action, which may include warnings, temporary restrictions, or permanent bans
+4. Communicate outcomes where appropriate
+
+---
+
+## Community Expectations
+
+- One issue per contributor at a time unless approved
+- Respect review feedback and maintainer decisions
+- Follow SWoC, GitHub, and project contribution guidelines
+- Zero tolerance for plagiarism or abusive behavior
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the  
+**Contributor Covenant, version 2.1**
+
+- https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+---
+
+By participating in this project, you agree to abide by this Code of Conduct.  
+Thank you for helping keep **Xaytheon** a welcoming and collaborative community.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -9,6 +9,10 @@ Please read this document carefully before contributing.
 
 ## How to Get Started
 
+**Please make sure to read and follow the Code of Conduct before contributing.*
+
+### Setup Instructions
+
 1. Star the repository (optional but appreciated)
 2. Fork the repository
 3. Clone your fork locally


### PR DESCRIPTION
## What changes have you done?

Added a `CODE_OF_CONDUCT.md` to establish clear behavioral guidelines for contributors.

The Code of Conduct:
- Sets expectations for respectful and inclusive collaboration
- Covers GitHub and Discord interactions
- Defines reporting and enforcement guidelines
- Aligns with open-source and SWoC best practices

## Why this change is needed

As the project grows and attracts new contributors, having a Code of Conduct helps ensure a safe, welcoming, and professional community.

## Related Issues

Fixed: #13 

## Screenshots / Logs

N/A – documentation-only change
