### PR TITLE
Fix hero section text overflow on mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,12 @@
                 <a class="logo" href="#home" aria-label="XAYTHEON home">
                     <img class="logo-img" src="assets/logo/thelogo.png" alt="XAYTHEON logo" />
                 </a>
+            <div class="hamburger" id="hamburger">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+                </div>
+
                 <ul class="nav-menu">
                     <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
                     <li><a class="nav-link" href="community.html">Community Highlights</a></li>

--- a/script.js
+++ b/script.js
@@ -1085,8 +1085,11 @@ function animateCursorTrail() {
 
 animateCursorTrail();
 
+const hamburger = document.getElementById("hamburger");
+const navMenu = document.querySelector(".nav-menu");
 
-
-
-
-
+if (hamburger && navMenu) {
+  hamburger.addEventListener("click", () => {
+    navMenu.classList.toggle("active");
+  });
+}

--- a/style.css
+++ b/style.css
@@ -1,3 +1,11 @@
+/* =========================
+   GLOBAL SAFETY FIX
+   ========================= */
+html, body {
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
 /* CSS Variables for Theming */
 :root {
     /* Light theme colors */
@@ -1116,4 +1124,98 @@ section {
 .cursor-dot:nth-child(7) { width: 9px;  height: 9px;  }
 .cursor-dot:nth-child(8) { width: 8px;  height: 8px;  }
 
+/* =========================
+   RESPONSIVENESS FIXES
+   ========================= */
+
+@media (max-width: 768px) {
+    .hero {
+    min-height: auto;
+    padding: 80px 16px 60px;
+}
+
+.hero-title {
+    line-height: 1.15;
+}
+
+.title-line {
+    font-size: 1.2em;
+}
+
+.title-main {
+    font-size: 2em;
+    letter-spacing: 0.5px;
+}
+
+.title-subtitle {
+    font-size: 1em;
+    line-height: 1.3;
+    text-align: center;
+}
+
+    .nav-container {
+        height: auto;
+        padding: 12px 15px;
+    }
+
+    .title-main {
+        font-size: 2.2em;
+        letter-spacing: 1px;
+        line-height: 1.2;
+    }
+
+    .title-logo-img {
+        height: 40px;
+    }
+
+    .title-subtitle {
+        font-size: 1.05em;
+        padding: 0 10px;
+    }
+
+    .mini-3d {
+        position: relative;
+        width: 100%;
+        height: 220px;
+        top: 0;
+        right: 0;
+        margin-top: 20px;
+    }
+
+    .cursor-container {
+        display: none;
+    }
+
+    /* Fix long hero text overflow on mobile */
+.hero-title,
+.title-subtitle {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.accent-glow {
+    letter-spacing: 0.3px;
+}
+
+}
+
+@media (max-width: 480px) {
+    .hero {
+    padding-top: 60px;
+}
+
+.title-main {
+    font-size: 1.7em;
+}
+
+    .title-main {
+        font-size: 1.9em;
+        letter-spacing: 0.5px;
+    }
+
+    .title-logo-img {
+        height: 34px;
+    }
+}
 


### PR DESCRIPTION
[Fixed issue #23] 

## Summary
Fixes an issue where long hero text (e.g., "COLLABORATION") overflowed the viewport on small screens.

## Changes
- Added mobile-only CSS overrides to allow proper text wrapping
- Ensured no impact on tablet or desktop layouts
- Navigation bar is visible & clickable now on mobile devices

## Testing
- Tested on iPhone SE viewport
- Verified no horizontal scrolling
- Confirmed desktop layout remains unchanged

## Screenshots
Before: Text overflowed beyond screen width  
After: Text wraps correctly within viewport

(Here are the before vs after fix comparison screenshots):
<img width="1920" height="1080" alt="Screenshot (392)" src="https://github.com/user-attachments/assets/c6faf1ba-7556-4a03-a7c2-71b441db71c5" />
<img width="1920" height="1080" alt="Screenshot (393)" src="https://github.com/user-attachments/assets/a7e25cbe-6067-47f8-9e84-b29855c7d2ad" />
<img width="1920" height="1080" alt="Screenshot (390)" src="https://github.com/user-attachments/assets/558737c5-b884-40d5-9fdf-aed427df0c61" />
<img width="1920" height="1080" alt="Screenshot (391)" src="https://github.com/user-attachments/assets/47d590c1-9093-46bc-a925-67aa51d5d376" />

