### PR TITLE
fix: issue #35 Add scroll to top to community highlights

### DIFF
--- a/community.html
+++ b/community.html
@@ -10,6 +10,9 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.44.4/dist/umd/supabase.min.js"></script>
   <script defer src="auth.js"></script>
 </head>
+<button id="scrollTopBtn" aria-label="Scroll to top">
+  ↑
+</button>
 <body class="eightgon-page">
   <div class="content">
     <nav class="navbar">

--- a/community.js
+++ b/community.js
@@ -227,3 +227,20 @@
   // Initial load with defaults
   update();
 })();
+
+const scrollTopBtn = document.getElementById("scrollTopBtn");
+
+window.addEventListener("scroll", () => {
+  if (window.scrollY > 300) {
+    scrollTopBtn.style.display = "flex";
+  } else {
+    scrollTopBtn.style.display = "none";
+  }
+});
+
+scrollTopBtn.addEventListener("click", () => {
+  window.scrollTo({
+    top: 0,
+    behavior: "smooth"
+  });
+});

--- a/script.js
+++ b/script.js
@@ -1252,3 +1252,4 @@ window.addEventListener("resize", () => {
     }
   }
 });
+

--- a/style.css
+++ b/style.css
@@ -1298,3 +1298,59 @@ section {
         word-break: break-word;
     }
 }
+
+#scrollTopBtn {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+
+  width: 46px;
+  height: 46px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 12px; /* modern rounded square */
+  border: 1.5px solid rgba(0, 0, 0, 0.15);
+
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+
+  color: #000;
+  font-size: 18px;
+  font-weight: 600;
+
+  cursor: pointer;
+  display: none;
+  z-index: 999;
+
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  transition: all 0.25s ease;
+}
+
+#scrollTopBtn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.15);
+  background: #000;
+  color: #fff;
+  border-color: #000;
+}
+
+#scrollTopBtn:active {
+  transform: translateY(-1px);
+}
+
+/* Dark mode */
+body.dark #scrollTopBtn {
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.2);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.5);
+}
+
+body.dark #scrollTopBtn:hover {
+  background: #fff;
+  color: #000;
+  border-color: #fff;
+}


### PR DESCRIPTION
Fixed issue #35 

This pull request introduces a Scroll to Top button on the Community Highlights page to improve navigation and overall user experience. The button appears once the user scrolls down and allows smooth scrolling back to the top of the page.

✨ Key Features
✅ Auto-visibility on scroll
The button becomes visible only after the user scrolls past a certain point.
🎯 Smooth scroll behavior
Clicking the button smoothly scrolls the page back to the top.
🎨 Minimal & professional UI
Uses a clean arrow character with modern styling (no SVG or external icons).
📱 Responsive & non-intrusive
Fixed positioning ensures it doesn’t interfere with content on any screen size.

📂 Files Changed
community.html
style.css
community.js

SCREENSHOTS
1) Button visible on scrolling down
<img width="1910" height="986" alt="Screenshot 2026-01-02 230106" src="https://github.com/user-attachments/assets/0b71d6ae-1d32-4f7b-aeb1-ad4a0e6be045" />
2) On clicking it navigates up
<img width="1919" height="981" alt="Screenshot 2026-01-02 230119" src="https://github.com/user-attachments/assets/2ca1cf77-84c1-47f6-8884-fb8f6dff7c1e" />
3) Button not visible when already at the top of the page.
<img width="1919" height="985" alt="Screenshot 2026-01-02 230127" src="https://github.com/user-attachments/assets/d0e94932-3d1d-481f-892b-3963a3112714" />


Please merge this under SWOC26

