### PR TITLE
Add project structure documentation and security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,50 @@ Features:
 **Purpose**: Maintains a comprehensive record of your open-source involvement and contributions.
 
 ---
+## Project Structure
+
+The project follows a modular structure, grouping related files by responsibility to keep the codebase organized and easy to maintain.
+
+xaytheon/
+│
+├── .github/                 # GitHub configs (issues, workflows)
+│
+├── assets/                  # Static assets
+│   ├── images/
+│   ├── icons/
+│
+├── pages/                   # HTML pages
+│   ├── index.html
+│   ├── login.html
+│   ├── github.html
+│   ├── community.html
+│   ├── explore.html
+│   └── contributions.html
+│
+├── js/                      # JavaScript logic
+│   ├── auth.js
+│   ├── script.js
+│   ├── github.js
+│   ├── community.js
+│   ├── explore.js
+│   └── contributions.js
+│
+├── css/                     # Stylesheets
+│   └── style.css
+│
+├── config/                  # Configuration & metadata
+│   ├── GithubAPI_info
+│   └── supabase.sql
+│
+├── docs/                    # Documentation
+│   ├── CONTRIBUTION.md
+│   └── windows_setup_guide.md
+│
+├── LICENSE.md               # License
+├── SECURITY.md              # Security policy
+├── README.md                # Project overview
+└── package.json (if added later)
+
 
 ## Technical Capabilities
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in **Xaytheon**, please report it responsibly.
+
+- **Do not** open a public GitHub issue for security-related vulnerabilities.
+- Instead, report the issue privately to the project maintainer.
+
+### How to Report
+Please use one of the following methods to report a vulnerability:
+- GitHub private message to the repository owner or maintainers
+- Any official contact method listed on the maintainer’s GitHub profile
+
+When reporting, please include:
+- A clear description of the vulnerability
+- Steps to reproduce the issue, if applicable
+- Any relevant logs, screenshots, or proof of concept
+
+## Responsible Disclosure
+
+We encourage responsible disclosure and appreciate efforts to report vulnerabilities in a secure and ethical manner.  
+The maintainers will make a best effort to acknowledge and address reported issues in a timely manner.
+
+Thank you for helping keep the project secure.


### PR DESCRIPTION
This pull request adds a Project Structure section to the README to improve clarity and onboarding for new contributors.

It also introduces a SECURITY.md file to define a responsible process for reporting security vulnerabilities and align the project with common open-source security best practices.

This work was completed as part of the assigned issue and follows the existing repository structure without introducing functional changes.

Closes #47 
