### PR TITLE
fix: adjust GitHub dashboard spacing to avoid logo overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -638,6 +638,11 @@ a:hover {
   pointer-events: none; /* purely decorative */
 }
 
+
+
+
+
+
 .mini-3d canvas {
   width: 100%;
   height: 100%;
@@ -674,6 +679,7 @@ a:hover {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   gap: 16px;
+  margin-top: 60px;
   align-items: end;
   margin-bottom: 30px;
 }


### PR DESCRIPTION
### Issue no.37
The animated GitHub logo on the GitHub Dashboard overlaps with the username input and action buttons, especially on larger screens. This affects visual clarity and user experience.

### Changes Made
- Adjusted vertical spacing of the GitHub Dashboard input section.
- Ensured sufficient separation between the animated logo and form elements.
- Maintained responsiveness across screen sizes.

### Result
- No overlap between the animated logo and dashboard controls.
- Cleaner and more readable layout.

### Screenshots
Before:
<img width="1239" height="275" alt="Screenshot 2026-01-05 172309" src="https://github.com/user-attachments/assets/2c61b482-7f4c-4ed9-afed-907641f8f776" />

After: 
<img width="1350" height="658" alt="Screenshot 2026-01-05 182323" src="https://github.com/user-attachments/assets/01c4c49f-ba99-4a2c-a58b-2a8a138e3413" />

