### PR TITLE
fix(styles): prevent navbar font from inheriting page font

### DIFF
--- a/style.css
+++ b/style.css
@@ -1020,6 +1020,15 @@ a:hover {
   gap: 20px;
 }
 
+
+/* Navbar typography lock – har page pe same header look */
+.navbar,
+.navbar * {
+  font-family: "Researcher", "OriginTech", "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  letter-spacing: normal;
+}
+
+
 @media (max-width: 890px) {
   .menu-icon {
     display: block;


### PR DESCRIPTION
What changed

Fixed inconsistent navbar/header typography across pages (Home vs dashboard/explore pages).

Scoped “Eightgon” font usage to page content only, so navbar doesn’t inherit it.

Ensured consistent letter-spacing in the navbar for a uniform look across the site.

Why

Some pages were applying a different font-family (via page-level class), which made the header look visually different and reduced UI consistency.


issue no-> #74 