### PR TITLE
fix(footer): update copyright year to 2026

### DIFF
--- a/community.html
+++ b/community.html
@@ -123,7 +123,7 @@
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2025 XAYTHEON. All rights reserved.</p>
+          <p>&copy; 2026 XAYTHEON. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/contributions.html
+++ b/contributions.html
@@ -127,7 +127,7 @@
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2025 XAYTHEON. All rights reserved.</p>
+          <p>&copy; 2026 XAYTHEON. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/explore.html
+++ b/explore.html
@@ -120,7 +120,7 @@
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2025 XAYTHEON. All rights reserved.</p>
+          <p>&copy; 2026 XAYTHEON. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/github.html
+++ b/github.html
@@ -144,7 +144,7 @@
           </div>
         </div>
         <div class="footer-bottom">
-          <p>&copy; 2025 XAYTHEON. All rights reserved.</p>
+          <p>&copy; 2026 XAYTHEON. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
                     <span class="footer-label">XAYTHEON</span>
                 </div>
                 <div class="footer-bottom">
-                    <p>&copy; 2025 XAYTHEON. All rights reserved.</p>
+                    <p>&copy; 2026 XAYTHEON. All rights reserved.</p>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
##  Update footer copyright year

### Issue
The footer was displaying an outdated copyright year (2025).
<img width="664" height="92" alt="image" src="https://github.com/user-attachments/assets/731d3658-eb7d-4b70-8765-4e580f456349" />

### Fix
Updated the footer across relevant pages to reflect the current year **2026**.
<img width="692" height="85" alt="image" src="https://github.com/user-attachments/assets/5a1b0a09-b35b-47ce-8d1d-8a97e4a66de9" />

Closes #78
