### PR TITLE
feat: add show/hide password toggle on sign-in page

### DIFF
--- a/login.html
+++ b/login.html
@@ -213,35 +213,107 @@
   </button>
 
   <div class="auth-wrap">
-    <div class="auth-card">
-      <div class="auth-title">Sign in</div>
-      <div class="auth-sub">Sign in using your email and password</div>
+  <div class="auth-card">
+    <div class="auth-title">Sign in</div>
+    <div class="auth-sub">Sign in using your email and password</div>
 
-      <form id="login-form" class="auth-form" autocomplete="on">
-        <label for="login-email">Email</label>
-        <input id="login-email" type="email" placeholder="you@example.com" required />
+    <form id="login-form" class="auth-form" autocomplete="on">
+      <label for="login-email">Email</label>
+      <input id="login-email" type="email" placeholder="you@example.com" required />
 
-        <label for="login-password">Password</label>
-        <input id="login-password" type="password" placeholder="••••••••" required />
-
-        <div class="auth-actions">
-          <button class="btn btn-primary" type="submit">Sign in</button>
-          <a class="btn btn-outline" href="index.html">Back</a>
-        </div>
-
-        <div id="login-status" class="status muted" aria-live="polite"></div>
-      </form>
-
-      <div class="center muted" style="margin-top:12px;">
-        New here?
-        <a href="register.html">Create an account</a>
+      <label for="login-password">Password</label>
+      <div class="password-wrapper">
+        <input
+          id="login-password"
+          type="password"
+          placeholder="••••••••"
+          required
+        />
+        <button
+          type="button"
+          class="toggle-password"
+          aria-label="Show password"
+          aria-pressed="false"
+        >
+          <img
+            id="eye-icon"
+            src="https://img.icons8.com/?size=100&id=59814&format=png&color=000000"
+            alt="Show password"
+          />
+        </button>
       </div>
 
-      <div class="center muted" style="margin-top:12px;">
-        Authentication is handled securely by the Xaytheon backend.
+      <div class="auth-actions">
+        <button class="btn btn-primary" type="submit">Sign in</button>
+        <a class="btn btn-outline" href="index.html">Back</a>
       </div>
+
+      <div id="login-status" class="status muted" aria-live="polite"></div>
+    </form>
+
+    <div class="center muted" style="margin-top:12px;">
+      New here?
+      <a href="register.html">Create an account</a>
+    </div>
+
+    <div class="center muted" style="margin-top:12px;">
+      Authentication is handled securely by the Xaytheon backend.
     </div>
   </div>
+</div>
+
+<!-- Inline CSS -->
+<style>
+  .password-wrapper {
+    position: relative;
+  }
+
+  .password-wrapper input {
+    width: 100%;
+    padding-right: 2.8rem;
+  }
+
+  .toggle-password {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .toggle-password img {
+    width: 20px;
+    height: 20px;
+  }
+</style>
+
+<!-- Inline JS -->
+<script>
+  const toggleBtn = document.querySelector(".toggle-password");
+  const passwordInput = document.getElementById("login-password");
+  const eyeIcon = document.getElementById("eye-icon");
+
+  toggleBtn.addEventListener("click", function () {
+    const isHidden = passwordInput.type === "password";
+
+    passwordInput.type = isHidden ? "text" : "password";
+
+    eyeIcon.src = isHidden
+      ? "https://img.icons8.com/?size=100&id=7840&format=png&color=000000"
+      : "https://img.icons8.com/?size=100&id=59814&format=png&color=000000";
+
+    eyeIcon.alt = isHidden ? "Hide password" : "Show password";
+    toggleBtn.setAttribute("aria-pressed", isHidden);
+    toggleBtn.setAttribute(
+      "aria-label",
+      isHidden ? "Hide password" : "Show password"
+    );
+  });
+</script>
+
 
   <script src="auth.js"></script>
   <script>


### PR DESCRIPTION
## Description
Added a show/hide password toggle on the Sign-in page.

## Changes
- Added eye icon inside password input
- Toggle switches between masked and visible password
- Accessible using aria-label and aria-pressed
- Works on desktop and mobile



##Proof 

[screen-capture.webm](https://github.com/user-attachments/assets/ea5d82a3-a8e9-43e1-9ebb-4bd96d71c543)

## Issue
Closes 
