### PR TITLE
fix: align theme toggle and Home button in navbar on auth pages

### DIFF
--- a/login.html
+++ b/login.html
@@ -98,7 +98,7 @@
     }
 
     .theme-toggle-auth {
-      position: fixed;
+      position: static;
       top: 20px;
       right: 20px;
       background: transparent;
@@ -191,13 +191,11 @@
       <a class="logo" href="index.html" aria-label="Back to Home">
         <img class="logo-img" src="assets/logo/thelogo.png" alt="XAYTHEON logo" />
       </a>
-      <ul class="nav-menu">
+      <div class="nav-right">
+          <ul class="nav-menu">
         <li><a class="nav-link" href="index.html">Home</a></li>
       </ul>
-    </div>
-  </nav>
-
-  <button class="theme-toggle-auth" id="theme-toggle-auth" aria-label="Toggle dark mode">
+      <button class="theme-toggle-auth" id="theme-toggle-auth" aria-label="Toggle dark mode">
     <svg class="theme-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
       stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <circle cx="12" cy="12" r="5" />
@@ -211,6 +209,12 @@
       <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
     </svg>
   </button>
+      </div>
+      
+    </div>
+  </nav>
+
+  
 
   <div class="auth-wrap">
   <div class="auth-card">

--- a/style.css
+++ b/style.css
@@ -253,6 +253,18 @@ body.eightgon-page {
   align-items: center;
   height: 70px;
 }
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+@media (max-width: 1100px) {
+  .nav-container {
+    flex-wrap: wrap;
+  }
+}
+
 
 .logo {
   display: flex;


### PR DESCRIPTION
Closes #127
## 🛠 Fix: Navbar overlap on auth pages (responsive)

### ❌ Issue
On certain screen sizes (Nest Hub, Surface Pro), the **Home button** and **theme (day/night) toggle** were overlapping on the login/auth pages due to responsive layout issues.

### ✅ What I changed
- Fixed navbar layout to prevent overlap between Home button and theme toggle
- Improved responsive behavior for mid-sized devices
- Adjusted flex wrapping behavior to maintain proper spacing

### 🧪 Tested on
- Desktop / Laptop
- Nest Hub
- Surface Pro
- Mobile devices (iPhone SE)

### 📸 Screenshots
<img width="769" height="573" alt="Screenshot 2026-01-11 131144" src="https://github.com/user-attachments/assets/8310750e-1d1b-4b7d-9d15-3bb41512a186" />



<img width="722" height="314" alt="Screenshot 2026-01-11 131131" src="https://github.com/user-attachments/assets/699056f0-3654-4295-ac15-39eb192463fb" />
