### PR TITLE
fix: improve password visibility icon contrast in dark mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/style.css
+++ b/style.css
@@ -87,6 +87,12 @@ body {
   --link-color: #93c5fd;
   --link-hover: #bfdbfe;
 }
+/* Dark mode: make eye icon visible */
+[data-theme="dark"] .toggle-password img {
+  filter: invert(1);
+}
+
+
 
 /* Reset and Base Styles */
 @font-face {


### PR DESCRIPTION
Closes #134 
## Fix: Password visibility icon not visible in dark mode

### Problem
In dark mode, the password visibility (eye) icon was not visible because the icon image uses a hard-coded dark color.

### Solution
- Applied a CSS filter to invert the eye icon color in dark mode.
- This ensures proper contrast and visibility without changing the HTML structure.

### Changes Made
- Added dark-mode specific CSS for `.toggle-password img`
- Improved accessibility and user experience in night mode

### Screenshots
<img width="698" height="590" alt="Screenshot 2026-01-11 172701" src="https://github.com/user-attachments/assets/05d5fbcf-d932-46e8-8548-1bcc1581f2b5" />


<img width="660" height="587" alt="Screenshot 2026-01-11 172712" src="https://github.com/user-attachments/assets/d7aee5e9-996a-4f50-9416-88ec772df4bb" />
