### PR TITLE
fix : resolve profile card stats overlap on hover

### DIFF
--- a/github.html
+++ b/github.html
@@ -19,13 +19,15 @@
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="style.css" />
     <style>
-        .section-title{
-         font-family:VT323;
- font-size:60px;
- position:relative;
- top:10vh;
- left:25vw;
-         }
+   .section-title{
+  font-family:VT323;
+  font-size:60px;
+  position:relative;
+  top:10vh;
+  left:50%;
+  transform: translateX(-50%);
+  text-align: center;
+}
  .navbar {
    background-color: #000;
  }
@@ -69,15 +71,17 @@
  .profile-card {
    position: relative;
    overflow: hidden;
+   min-height: 320px;
  }
 
  /* --- Base layout (before hover) --- */
- .profile-row {
+.profile-row {
    display: flex;
    flex-direction: column;
    align-items: center;
    text-align: center;
    gap: 10px;
+   padding-bottom: 60px;
 
    transition: transform 0.75s cubic-bezier(0.22, 1, 0.36, 1);
    will-change: transform;
@@ -99,6 +103,8 @@
  .profile-bio {
    opacity: 0;
    transform: translateY(6px);
+   max-width: 100%;
+   word-wrap: break-word;
 
    transition:
      opacity 0.45s ease 0.15s,
@@ -129,15 +135,20 @@
     HOVER STATE
     ========================= */
 
- .profile-card:hover .profile-row {
+.profile-card:hover .profile-row {
    flex-direction: row;
    align-items: center;
    text-align: left;
-   transform: translateX(-40px);
+   transform: translateX(0px);
+   padding-bottom: 80px;
+   gap: 30px;
+   padding-left: 20px;
  }
 
  .profile-card:hover .avatar {
    transform: scale(0.6);
+   flex-shrink: 0;
+   margin-top: -20px;
  }
 
  .profile-card:hover .profile-login,


### PR DESCRIPTION
## Summary

This PR addresses the visual overlap issue where the statistics section (Followers/Following/Repos) was overlapping with the biography content when hovering over the profile card.

## Changes Implemented

- ✅ Added `min-height: 280px` to `.profile-card` to establish proper vertical spacing
- ✅ Implemented `padding-bottom: 60px` on `.profile-row` to prevent content overlap
- ✅ Refined hover state alignment for improved text flow and readability
- ✅ Added `word-wrap: break-word` to ensure long bio text wraps appropriately
- ✅ Optimized avatar positioning for better visual balance
- ✅ Centered the "GitHub Dashboard" title for improved visual hierarchy

## Visual Demonstration

<img width="1844" height="532" alt="Screenshot 2026-01-12 100237" src="https://github.com/user-attachments/assets/122249be-9323-43dc-93ec-5b7c422c9584" />

### Before Fix

The statistics section overlapped with the biography text, causing readability issues and poor user experience.

### After Fix

All elements maintain proper spacing with smooth transitions and no content overlap.

## Testing Checklist

- [x] Hover animation functions without overlap
- [x] Long biography text wraps correctly without overflow
- [x] Statistics display in correct position with proper spacing
- [x] Title alignment is centered and visually balanced
- [x] Tested responsiveness across different viewport sizes