### PR TITLE
fix: improve dark mode text contrast in Explore by Topic & Community …

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,6 +91,12 @@ body {
 [data-theme="dark"] .toggle-password img {
   filter: invert(1);
 }
+/* Fix low-contrast status text in dark mode */
+[data-theme="dark"] .github-status {
+  color: #e5e7eb !important;
+}
+
+
 
 
 


### PR DESCRIPTION
## Issue #157 
## 🐛 Issue
In dark mode, status and helper text in **Explore by Topic** and **Community Highlights** sections had very low contrast, making it hard to read.

## ✅ What was changed
- Updated text color for status messages in dark mode
- Ensured consistent contrast with dark background

## 🖼️ Screenshots
<img width="1310" height="374" alt="Screenshot 2026-01-13 043021" src="https://github.com/user-attachments/assets/5030aee9-723f-41ed-95e8-6fd918ebb9ad" />


<img width="1180" height="441" alt="Screenshot 2026-01-13 043314" src="https://github.com/user-attachments/assets/7514481d-ddab-4669-9747-ff1fb170b9e4" />
