### PR TITLE
Fix spacing between Watchlists header and New button

### DIFF
--- a/watchlist.css
+++ b/watchlist.css
@@ -32,6 +32,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 12px;     
     margin-bottom: 20px;
     padding-bottom: 12px;
     border-bottom: 1px solid var(--border-color);


### PR DESCRIPTION
### What was the issue?
The "+ New" button overlapped the "Watchlists" heading on smaller screen sizes, making the title unclear.

### What did I change?
- Created the CSS gap value in the watchlist header
- Increased spacing between the title and the "+ New" button

### Why this change?
Improves readability and makes the watchlist header clearer without changing the existing layout.

before : 
![WhatsApp Image 2026-01-12 at 8 57 34 PM](https://github.com/user-attachments/assets/d3cc3a8d-7752-42e3-ac71-9503708ffbb6)

After :
![WhatsApp Image 2026-01-13 at 8 29 18 PM](https://github.com/user-attachments/assets/0a041ea9-20ac-438f-b583-d3707d526cc0)

### Testing
- Checked layout on desktop
- Tested mobile view using browser dev tools


