### PR TITLE
GitHub Dashboard modification

### DIFF
--- a/github.html
+++ b/github.html
@@ -154,10 +154,17 @@
     }
 
     /* Profile card animation */
+
+    .github-grid {
+     display: flex;
+     flex-direction: row;
+   }
+
     .profile-card {
       position: relative;
       overflow: hidden;
       min-height: 320px;
+      width: 100%;
     }
 
     .profile-row {
@@ -194,8 +201,8 @@
 
     .profile-stats {
       position: absolute;
-      bottom: 20px;
-      left: 50%;
+      bottom: 100px;
+      margin-left: 120px;
       transform: translate(-50%, 20px);
       opacity: 0;
       display: flex;
@@ -472,7 +479,8 @@
                 </div>
                 <div class="card-body">
                   <div class="profile-row">
-                    <img id="gh-avatar" alt="Avatar" class="avatar" />
+                    <img id="gh-avatar" src="https://api.dicebear.com/9.x/identicon/svg?seed=Liliana" alt="Avatar"
+                   class="avatar" />
                     <div>
                       <div class="profile-name" id="gh-name">—</div>
                       <div class="profile-login" id="gh-login">—</div>


### PR DESCRIPTION
**Before:**

- No default avatar, just an alt text "Avatar"
- Profile stats appear below the contributions section on hovering and thus is not visible without scrolling down

**After:**

- Major impact is -  now profile stats appear right below avatar on hovering
- Default avatar is set, matching the theme

Corresponding Issue: #168 