### PR TITLE
fix(Register Page): Add explicit login link for existing users

### DIFF
--- a/register.html
+++ b/register.html
@@ -196,6 +196,13 @@
           <a class="btn btn-outline" href="login.html">Back</a>
         </div>
 
+        <div class="center muted" style="margin-top:16px;">
+          Already have an account?
+          <a href="login.html" style="color: var(--text-primary); font-weight: 600;">
+            Login
+          </a>
+        </div>
+
         <div class="center muted" style="margin-top:12px;">
           Authentication is handled securely by the Xaytheon backend.
         </div>


### PR DESCRIPTION
- Added a clear "Already have an account? Login" message below the registration form.
- Provides a direct link to `login.html` for users who land on the register page.
- Keeps existing Back button intact (optional UX improvement).
- Improves usability and navigation for existing users.

Users currently land on the Register page without an obvious way to navigate to Login. This fix ensures users can easily switch to the login page, improving overall user experience.

Closes #178
