### PR TITLE
Implement recency-weighted repository trend scoring

### DIFF
--- a/js/utils/trendScore.js
+++ b/js/utils/trendScore.js
@@ -2,12 +2,27 @@ export function calculateTrendScore(repo) {
   const totalStars = repo.stargazers_count || 0;
   const totalForks = repo.forks_count || 0;
 
-  // Log normalization to reduce bias toward very large repositories
   const starsScore = Math.log1p(totalStars);
   const forksScore = Math.log1p(totalForks);
 
-  // Combine stars and forks (growth signals only)
-  const trendScore = (0.6 * starsScore) + (0.4 * forksScore);
+  // Commit recency score using exponential decay
+  const lastPushedAt = repo.pushed_at;
+  let recencyScore = 0;
+
+  if (lastPushedAt) {
+    const daysSinceLastCommit =
+      (Date.now() - new Date(lastPushedAt).getTime()) /
+      (1000 * 60 * 60 * 24);
+
+    const decayFactor = 30; // days
+    recencyScore = Math.exp(-daysSinceLastCommit / decayFactor);
+  }
+
+  // Final weighted trend score
+  const trendScore =
+    (0.4 * starsScore) +
+    (0.3 * forksScore) +
+    (0.3 * recencyScore);
 
   return Number(trendScore.toFixed(4));
 }


### PR DESCRIPTION
### Summary
This PR introduces a transparent, recency-weighted trend scoring algorithm for repositories in the Explore section.

### What’s included
- Added a reusable `calculateTrendScore` utility combining:
  - Stars (log-normalized)
  - Forks (log-normalized)
  - Commit recency (exponential decay)
- Ranked repositories in Explore → List View using the computed `trendScore`
- Ensured sorting does not mutate original data

### Why this matters
- Improves discovery quality
- Avoids bias toward old but inactive repositories
- Makes trending results more meaningful and actionable

### Notes
- Graph view and API logic are untouched
- Sorting is applied only at render time for safety
