### PR TITLE
Fix Risk Detector page content hidden behind fixed navbar

### DIFF
--- a/risk.css
+++ b/risk.css
@@ -1,7 +1,7 @@
 .risk-container {
     max-width: 1300px;
-    margin: 40px auto;
-    padding: 0 20px;
+    margin: 0 auto;
+    padding: 110px 20px 40px;
 }
 
 .risk-header {


### PR DESCRIPTION
📝 Description

Fixed the issue where the Risk Detector page content was hidden behind the fixed navbar by adding proper spacing so content starts below the navbar.

🔗 Related Issue
Closes #341 

🏷️ Type of Change
- Bug fix
- Style/UI update

✅ Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have tested my changes locally

🧪 Testing
 - Tested on Chrome
 
📋 Additional Notes
- Improves layout consistency and user experience across pages with fixed navbars.