### PR TITLE
fix/theme-toggle-workflow-builder

### DIFF
--- a/workflow-builder.html
+++ b/workflow-builder.html
@@ -183,7 +183,7 @@
 
     <script type="module" src="./app.js"></script>
     <script src="boilerplate/boilerplate-loader.js"></script>
-
+    <script src="theme.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## 📝 Description

Fixed the theme toggle button issue on `workflow-builder.html`.

Resolved the moon icon visibility and styling problem in dark theme, and ensured the toggle properly switches between light and dark modes.

## 🔗 Related Issue
Closes #343 

## 🏷️ Type of Change
- Bug fix (non-breaking change that fixes an issue)

## ✅ Checklist
- My code follows the project's style guidelines
- I have performed a self-review of my code
- I have tested my changes locally

## 🧪 Testing
- Tested on Chrome
