### PR TITLE
Fix null addEventListener crash for mobile menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -1549,31 +1549,30 @@ const menuIcon = document.querySelector(".menu-icon");
 const menuCloseIcon = document.querySelector(".menu-close-icon");
 const navMenu = document.querySelector(".nav-menu");
 
-// Open Menu
-menuIcon.addEventListener("click", () => {
-  navMenu.classList.add("active");
-  menuIcon.style.display = "none";
-  menuCloseIcon.style.display = "block";
-});
-
-// Close Menu
-menuCloseIcon.addEventListener("click", () => {
-  navMenu.classList.remove("active");
-  menuIcon.style.display = "block";
-  menuCloseIcon.style.display = "none";
-});
-
-window.addEventListener("resize", () => {
-  if (window.innerWidth > 890) {
-    navMenu.classList.remove("active");
+if (menuIcon && menuCloseIcon && navMenu) {
+  menuIcon.addEventListener("click", () => {
+    navMenu.classList.add("active");
     menuIcon.style.display = "none";
+    menuCloseIcon.style.display = "block";
+  });
+
+  menuCloseIcon.addEventListener("click", () => {
+    navMenu.classList.remove("active");
+    menuIcon.style.display = "block";
     menuCloseIcon.style.display = "none";
-  } else {
-    if (!navMenu.classList.contains("active")) {
+  });
+
+  window.addEventListener("resize", () => {
+    if (window.innerWidth > 890) {
+      navMenu.classList.remove("active");
+      menuIcon.style.display = "none";
+      menuCloseIcon.style.display = "none";
+    } else if (!navMenu.classList.contains("active")) {
       menuIcon.style.display = "block";
     }
-  }
-});
+  });
+}
+
 
 
 // ===================== Recommendation Engine =====================


### PR DESCRIPTION
## 📝 Description
Fixes a JavaScript runtime error caused by attaching event listeners to DOM elements that are not present on all pages.

The mobile navbar menu logic was running globally, which resulted in a `null.addEventListener` error on pages where `.menu-icon` and `.menu-close-icon` do not exist.  
This PR adds proper null checks before registering event listeners, preventing the application from crashing.

## 🔗 Related Issue
Closes #383 

## 🏷️ Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 📸 Screenshots
<img width="1278" height="413" alt="Screenshot 2026-01-30 020649" src="https://github.com/user-attachments/assets/6064476c-8e24-4403-8769-a1960190080e" />
<img width="1296" height="462" alt="Screenshot 2026-01-30 020640" src="https://github.com/user-attachments/assets/771660df-05d3-458a-900a-0fd3041d1e44" />
<img width="1338" height="453" alt="Screenshot 2026-01-30 020634" src="https://github.com/user-attachments/assets/7035f215-ecae-4ce1-ba7f-593218ed0143" />

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## 🧪 Testing
- [x] Tested on Chrome
- [x] Tested on mobile

Verified that pages without mobile menu icons no longer throw console errors and that the menu works correctly where present.


