### PR TITLE
Add the previousFocusedElement variable to builder.js

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -24,6 +24,7 @@ const elements = {
     let workflowSteps = [];
     let editingStepId = null;
     let draggedStepId = null;
+    let previousFocusedElement = null;
 
     /* -------------------- Utilities -------------------- */
     function generateStepId() {


### PR DESCRIPTION
## 📝 Description

<!-- Describe your changes in detail -->
This PR fixes a runtime error in the builder edit modal by declaring the previously undeclared `previousFocusedElement` variable. 

## 🔗 Related Issue

<!-- Link to the issue this PR addresses -->

Closes #511 

## 🏷️ Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## ✅ Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## 🧪 Testing

<!-- Describe how you tested your changes -->

- [ ] Tested on Chrome
- [x] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes

<!-- Any additional information for reviewers -->

---

**SWOC 2026 Participant?** Add `swoc2026` label to your PR! 🎉
