### PR TITLE
Fix three.js version and defer the external scripts in `security-fuzzer.html`

### DIFF
--- a/security-fuzzer.html
+++ b/security-fuzzer.html
@@ -6,8 +6,8 @@
     <title>Security Fuzzer - Xaytheon</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="security-fuzzer.css">
-    <script src="https://cdn.jsdelivr.net/npm/three@0160.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0160.0/examples/js/controls/OrbitControls.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/controls/OrbitControls.js"></script>
 </head>
 <body>
     <div id="navbar-container"></div>
@@ -145,9 +145,9 @@
 
     <input type="file" id="file-input" accept=".json" style="display:none;">
 
-    <script src="i18n.js"></script>
-    <script src="theme.js"></script>
-    <script src="auth.js"></script>
-    <script src="security-fuzzer.js"></script>
+    <script defer src="i18n.js"></script>
+    <script defer src="theme.js"></script>
+    <script defer src="auth.js"></script>
+    <script defer src="security-fuzzer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## 📝 Description

<!-- Describe your changes in detail -->

This PR fixes the malformed Three.js CDN version path and also loads heavy external scripts without the defer attribute, potentially causing 404 errors and blocking page rendering.

## 🔗 Related Issue

<!-- Link to the issue this PR addresses -->

Closes #548 

## 🏷️ Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [x] ⚡ Performance improvement
- [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## ✅ Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## 🧪 Testing

<!-- Describe how you tested your changes -->

- [ ] Tested on Chrome
- [x] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes

<!-- Any additional information for reviewers -->

---

**SWOC 2026 Participant?** Add `swoc2026` label to your PR! 🎉
