### PR TITLE
fix: Disable Mock GitHub Service in Production Environment

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -15,8 +15,13 @@ server.listen(PORT, () => {
   console.log(`🚀 Auth server running on port ${PORT}`);
   console.log(`🔌 WebSocket server ready`);
 
-  // Start mock service for demo
-  mockGithubService.start();
+  // Start mock service only in non-production environments
+  if (process.env.NODE_ENV !== "production") {
+    console.log("[MockService] Starting mock GitHub service (development/test mode)");
+    mockGithubService.start();
+  } else {
+    console.log("[MockService] Skipping mock GitHub service in production environment");
+  }
 
   // Start Analytics Queue Worker
   require('./worker/analytics.worker');


### PR DESCRIPTION
Problem
In `backend/src/server.js`, the mock GitHub service was being started unconditionally on every server boot:
```
// Start mock service for demo
mockGithubService.start();
```
This means even in a production deployment, the mock service would run wasting resources, potentially interfering with real WebSocket operations, and creating security confusion.

Solution
Wrapped `mockGithubService.start()` inside an environment check so it only runs in development or test environments:
```
// Start mock service only in non-production environments
if (process.env.NODE_ENV !== "production") {
  console.log("[MockService] Starting mock GitHub service (development/test mode)");
  mockGithubService.start();
} else {
  console.log("[MockService] Skipping mock GitHub service in production environment");
}
```

Files Changed

`backend/src/server.js`


How to Test
Development (mock should run):
```
NODE_ENV=development node src/server.js
# Expected log: [MockService] Starting mock GitHub service (development/test mode)
```
Production (mock should be skipped):
```
NODE_ENV=production node src/server.js
# Expected log: [MockService] Skipping mock GitHub service in production environment
```

Related Issue

closes #587

Checklist:

 

- [x] Code follows the project's existing style
- [x]  Only one file modified (server.js)
- [x]  No new dependencies added
- [x]  Tested in both development and production modes