### PR TITLE
fix: handle private GitHub emails in authentication flow

### DIFF
--- a/backend/src/services/github.service.js
+++ b/backend/src/services/github.service.js
@@ -70,6 +70,22 @@ class GithubService {
         }
     }
 
+    // NEW: Fetch all email addresses for the user (including private ones)
+    async fetchUserEmails(accessToken) {
+        try {
+            const response = await axios.get(`${this.baseUrl}/user/emails`, {
+                headers: {
+                    ...this.headers,
+                    Authorization: `token ${accessToken}`
+                }
+            });
+            return response.data;
+        } catch (error) {
+            console.error('Error fetching user emails:', error.message);
+            throw error;
+        }
+    }
+
     async getAnalyticsData(username) {
         const [user, repos] = await Promise.all([
             this.fetchUserData(username),


### PR DESCRIPTION
Description
This PR fixes a bug where users with private email addresses on GitHub were unable to authenticate. Although the application requests the user:email scope, the public profile object returned by GitHub does not include private emails.

Changes implemented:

- backend/src/services/github.service.js: Added a new fetchUserEmails method to retrieve the full list of email addresses associated with an account using the OAuth access token.
- backend/src/controllers/auth.controller.js: Updated the githubCallback logic to check for a null email. If the public email is missing, the controller now calls the new service method to find the user's primary verified email address.

🔗 Related Issue

closes #585

Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published