### PR TITLE
Add dark mode toggle with persistent theme support

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,15 +26,21 @@
     <!-- Navigation Bar -->
     <nav class="navbar">
       <div class="nav-container">
-        <a class="logo" href="index.html" aria-label="XAYTHEON home">
-          <img class="logo-img" src="assets/logo/thelogo.png" alt="XAYTHEON logo" />
-        </a>
-        <ul class="nav-menu">
-          <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
-          <li><a class="nav-link" href="community.html">Community Highlights</a></li>
-          <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
-          <li><a class="nav-link" href="contributions.html">Contributions</a></li>
-        </ul>
+      <a class="logo" href="index.html" aria-label="XAYTHEON home">
+      <img class="logo-img" src="assets/logo/thelogo.png" alt="XAYTHEON logo" />
+      </a>
+
+      <ul class="nav-menu">
+      <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
+      <li><a class="nav-link" href="community.html">Community Highlights</a></li>
+      <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
+      <li><a class="nav-link" href="contributions.html">Contributions</a></li>
+      </ul>
+
+          <!-- Dark Mode Toggle -->
+          <button id="theme-toggle" class="theme-toggle">
+            🌙
+        </button>
       </div>
     </nav>
 

--- a/script.js
+++ b/script.js
@@ -879,3 +879,38 @@ document.addEventListener('DOMContentLoaded', function() {
   initMiniViewer();
 
 });
+
+/* =========================
+   DARK MODE TOGGLE
+========================= */
+
+document.addEventListener("DOMContentLoaded", () => {
+
+  const themeToggle = document.getElementById("theme-toggle");
+
+  if (!themeToggle) return;
+
+  // Load saved theme
+  if (localStorage.getItem("theme") === "dark") {
+    document.body.classList.add("dark-mode");
+    themeToggle.textContent = "☀️";
+  } else {
+    themeToggle.textContent = "🌙";
+  }
+
+  // Toggle theme
+  themeToggle.addEventListener("click", () => {
+
+    document.body.classList.toggle("dark-mode");
+
+    if (document.body.classList.contains("dark-mode")) {
+      localStorage.setItem("theme", "dark");
+      themeToggle.textContent = "☀️";
+    } else {
+      localStorage.setItem("theme", "light");
+      themeToggle.textContent = "🌙";
+    }
+
+  });
+
+});

--- a/style.css
+++ b/style.css
@@ -903,3 +903,69 @@ section {
 .contact-method:hover::before {
     opacity: 1;
 }
+
+
+/* =========================
+   DARK MODE
+========================= */
+
+.theme-toggle {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 1px solid rgba(0,0,0,0.15);
+    background: rgba(255,255,255,0.7);
+    cursor: pointer;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.3s ease;
+}
+
+.theme-toggle:hover {
+    transform: scale(1.08);
+    background: rgba(240,240,240,0.9);
+}
+
+/* Dark body */
+body.dark-mode {
+    background: #121212;
+    color: #ffffff;
+}
+
+/* Canvas background */
+body.dark-mode .canvas-container {
+    background: #121212;
+}
+
+/* Navbar */
+body.dark-mode .navbar {
+    background: rgba(0,0,0,0.92);
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+/* Nav links */
+body.dark-mode .nav-link {
+    color: #ffffff;
+}
+
+body.dark-mode .nav-link::after {
+    background: #ffffff;
+}
+
+/* Hero text */
+body.dark-mode .title-line,
+body.dark-mode .title-subtitle,
+body.dark-mode p,
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+    color: #ffffff;
+}
+
+/* Footer */
+body.dark-mode .footer {
+    background: #000000;
+    color: white;
+}


### PR DESCRIPTION
 Description

Implemented a dark mode toggle feature for the XAYTHEON home page.

Features Added

 Added 🌙 / ☀️ theme toggle button in navbar
 Implemented light and dark mode UI support
 Added theme persistence using localStorage
 Maintained responsive and consistent styling

Changes Made

 Updated `index.html`
 Added dark mode styles in `style.css`
 Added theme toggle functionality in `script.js`

Closes #769
