### PR TITLE
fix: resolve race condition in contribution chart rendering (#718)

### DIFF
--- a/script.js
+++ b/script.js
@@ -607,14 +607,17 @@ function showContributionsChart(username, events) {
   var noteEl    = document.getElementById('gh-contrib-note');
   if (!container) return;
 
+  // Show placeholder before anything else so it can't overwrite the result
+  container.innerHTML = '<div class="muted">Loading contributions chart…</div>';
+
   // Try the third-party full-year chart image first
   var chartImg = new Image();
-  chartImg.src              = 'https://ghchart.rshah.org/' + encodeURIComponent(username);
   chartImg.alt              = username + "'s contributions";
   chartImg.style.maxWidth   = '100%';
   chartImg.referrerPolicy   = 'no-referrer';
 
-  // If the image loads — display it
+  // Attach handlers BEFORE setting src to avoid a race condition where a
+  // cached image fires onload synchronously before the handler is registered.
   chartImg.onload = function() {
     container.innerHTML = '';
     container.appendChild(chartImg);
@@ -628,7 +631,18 @@ function showContributionsChart(username, events) {
     if (noteEl) noteEl.textContent = 'Approximate heatmap based on recent public activity.';
   };
 
-  container.innerHTML = '<div class="muted">Loading contributions chart…</div>';
+  // Set src last so the browser starts loading only after handlers are in place.
+  chartImg.src = 'https://ghchart.rshah.org/' + encodeURIComponent(username);
+
+  // Safety net: if the browser resolved the image from cache synchronously
+  // before onload could fire, manually trigger the appropriate handler.
+  if (chartImg.complete) {
+    if (chartImg.naturalWidth > 0) {
+      chartImg.onload();
+    } else {
+      chartImg.onerror();
+    }
+  }
 }
 
 


### PR DESCRIPTION
…on (#718)

## 📝 Description

Fixes a race condition in the contribution chart rendering. In `script.js` 
(lines 611-631), `chartImg.src` was set before `onload` and `onerror` handlers 
were attached. When the browser served the image from cache, `onload` could 
fire synchronously the moment `src` was assigned, before the handler existed,
causing the chart to silently fail and remain stuck on "Loading contributions 
chart..." with no console error.

The fix has three parts:

1. Moves handler attachment to before `src` assignment, guaranteeing the 
   handlers are registered before the load event can fire.
2. Moves the "Loading..." placeholder to the start of the function so it 
   cannot overwrite the rendered chart on a synchronous cached load.
3. Adds an `if (chartImg.complete)` safety net that manually fires the 
   appropriate handler if the browser resolved the image before this point 
   in execution, as a defense for any remaining edge cases.

## 🔗 Related Issue

Closes #718: [BUG] Race condition in contribution chart, onload/onerror 
attached after src is set. This PR implements the fix proposed in the issue.

Closes #718

## 🏷️ Type of Change

<!-- Mark the relevant option with an "x" -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

N/A. This is a silent failure with no visible UI diff. Chart renders correctly after fix.

## ✅ Checklist

<!-- Mark completed items with an "x" -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## 🧪 Testing

Tested by loading the page with cache enabled, then performing hard refresh 
(Cmd+Shift+R) followed by normal refresh (Cmd+R) cycles 20+ times. Chart 
renders reliably in all cases. Verified `onerror` still fires correctly by 
temporarily pointing `src` at an invalid username.

Environment: Brave 1.89.137 (Chromium 147.0.7727.102) on macOS Monterey 12.7.6

## 📋 Additional Notes

This is the issue I reported in #718. The root cause analysis there describes 
the bug in more detail.