### PR TITLE
fix: extract username from full GitHub URL in dashboard input

### DIFF
--- a/script.js
+++ b/script.js
@@ -394,6 +394,13 @@ function initGithubDashboard() {
       return;
     }
 
+    // If the user pasted a full GitHub URL, extract just the username
+    var urlMatch = username.match(/github\.com\/([^/?#\s]+)/);
+    if (urlMatch) {
+      username = urlMatch[1];
+      usernameInput.value = username;
+    }
+
     localStorage.setItem('xaytheon:ghUsername', username);
     loadGithubDashboard(username);
   });


### PR DESCRIPTION
## Summary

Fixes #815

When a user pastes a full GitHub profile URL (e.g. `https://github.com/username`) into the "GitHub Username" input field, the app was sending the raw URL directly to the GitHub API, which returned a `404 Not Found` error.

### Root cause
No input sanitization was applied before passing the value to `loadGithubDashboard()`.

### Fix
Added a regex check after trimming the input. If the value matches a GitHub URL pattern, the username is extracted and the input field is updated to show the clean username:

```js
var urlMatch = username.match(/github\.com\/([^/?#\s]+)/);
if (urlMatch) {
  username = urlMatch[1];
  usernameInput.value = username;
}
```

## Test plan
- [ ] Enter `https://github.com/octocat` → dashboard loads correctly for `octocat`
- [ ] Enter `github.com/octocat` (no protocol) → dashboard loads correctly
- [ ] Enter plain `octocat` → behavior unchanged
- [ ] Enter empty string → validation error still shown