### PR TITLE
fix: show user-friendly error messages instead of raw GitHub API errors

### DIFF
--- a/script.js
+++ b/script.js
@@ -490,8 +490,15 @@ async function fetchFromGitHub(url) {
   });
 
   if (!response.ok) {
-    var errorText = await response.text();
-    throw new Error('GitHub API ' + response.status + ': ' + errorText);
+    var friendlyMsg;
+    switch (response.status) {
+      case 404: friendlyMsg = 'GitHub user not found. Please check the username and try again.'; break;
+      case 403: friendlyMsg = 'GitHub API rate limit exceeded. Please try again later.'; break;
+      case 401: friendlyMsg = 'Authentication required. Please check your GitHub token.'; break;
+      case 422: friendlyMsg = 'Invalid request. Please check the username format.'; break;
+      default:  friendlyMsg = 'Unable to load GitHub data right now. (Error ' + response.status + ')';
+    }
+    throw new Error(friendlyMsg);
   }
 
   return response.json();  // parse and return the JSON data


### PR DESCRIPTION
## Summary

Fixes #811

The `fetchFromGitHub()` function was throwing raw API error text (e.g. `GitHub API 404: {"message":"Not Found","documentation_url":"..."}`) which was then displayed directly in the UI.

### Fix
Replaced raw error text with clear, status-code-specific messages in `fetchFromGitHub()`:

| Status | Message |
|--------|---------|
| 404 | GitHub user not found. Please check the username and try again. |
| 403 | GitHub API rate limit exceeded. Please try again later. |
| 401 | Authentication required. Please check your GitHub token. |
| 422 | Invalid request. Please check the username format. |
| other | Unable to load GitHub data right now. (Error `<status>`) |

## Test plan
- [ ] Enter a non-existent username → shows "GitHub user not found..." message
- [ ] Trigger rate limit → shows "GitHub API rate limit exceeded..." message
- [ ] Network error on valid username → shows generic error with status code