### PR TITLE
fix: highlight active nav link for current page

### DIFF
--- a/script.js
+++ b/script.js
@@ -892,4 +892,13 @@ document.addEventListener('DOMContentLoaded', function() {
   // Set up the mini 3D viewer if we're on github.html
   initMiniViewer();
 
+  // Mark the current page's nav link as active
+  var currentPage = window.location.pathname.split('/').pop() || 'index.html';
+  document.querySelectorAll('.nav-link').forEach(function(link) {
+    var linkPage = link.getAttribute('href').split('/').pop();
+    if (linkPage === currentPage) {
+      link.classList.add('active');
+    }
+  });
+
 });

--- a/style.css
+++ b/style.css
@@ -221,6 +221,15 @@ body.eightgon-page {
     width: 100%;
 }
 
+.nav-link.active {
+    opacity: 100%;
+    font-weight: 700;
+}
+
+.nav-link.active::after {
+    width: 100%;
+}
+
 /* Auth user dropdown */
 .user-menu { position: relative; display: flex; align-items: center; }
 .user-button { background: transparent; border: none; border-radius: 999px; padding: 4px 6px; cursor: pointer; font: inherit; display: inline-flex; align-items: center; gap: 6px; }


### PR DESCRIPTION
## Summary

Fixes #732

Navbar links had no active state — there was no visual indicator showing which page the user is currently on. This fix adds both the JavaScript to detect the current page and the CSS to style it.

### Changes

**`script.js`** — inside the existing `DOMContentLoaded` handler:
```js
var currentPage = window.location.pathname.split('/').pop() || 'index.html';
document.querySelectorAll('.nav-link').forEach(function(link) {
  var linkPage = link.getAttribute('href').split('/').pop();
  if (linkPage === currentPage) link.classList.add('active');
});
```

**`style.css`** — new rules for `.nav-link.active`:
```css
.nav-link.active {
  opacity: 100%;
  font-weight: 700;
}
.nav-link.active::after {
  width: 100%;   /* persistent underline */
}
```

## Test plan
- [ ] Visit `github.html` → "GitHub Dashboard" link is bold with underline
- [ ] Visit `community.html` → "Community Highlights" link is active
- [ ] Visit `explore.html` → "Explore by Topic" link is active
- [ ] Visit `contributions.html` → "Contributions" link is active
- [ ] Visit `index.html` → "Home" link is active
- [ ] Hover on non-active links still shows hover underline