### PR TITLE
Fix navbar font inconsistency across pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -197,6 +197,7 @@ body.eightgon-page {
     text-decoration: none;
     color: var(--text-color);
     font-weight: 500;
+    font-family: 'Researcher', 'OriginTech', sans-serif;
     transition: all 0.3s ease;
     position: relative;
 }


### PR DESCRIPTION
## Description

Resolved inconsistent navbar font styling across different pages by explicitly defining the font-family for navigation links instead of relying on inherited page-level styles.

## Changes Made

* Added a dedicated `font-family` property to `.nav-link`
* Ensured consistent navbar appearance across all pages

Fixes #858
