### PR TITLE
fix: use kusa chart service for dark mode contribution graph support

### DIFF
--- a/github.html
+++ b/github.html
@@ -152,7 +152,12 @@
         document.documentElement.setAttribute('data-theme', newTheme);
         localStorage.setItem('theme', newTheme);
         updateButtonLabel(newTheme);
-        console.log(currentTheme);
+
+        // Reload the contributions chart with the updated theme without a new API call
+        var savedUsername = localStorage.getItem('xaytheon:ghUsername');
+        if (savedUsername && lastFetchedEvents) {
+            showContributionsChart(savedUsername, lastFetchedEvents);
+        }
     });
 
     function updateButtonLabel(theme) {

--- a/script.js
+++ b/script.js
@@ -31,6 +31,8 @@ var renderer;  // Draws everything onto the HTML canvas
 var currentMesh;   // The current primitive shape (cube, sphere, etc.)
 var currentModel;  // The current loaded 3D model (.glb file)
 
+var lastFetchedEvents = null;  // Stores the last fetched events for theme-aware chart reloads
+
 var autoRotationSpeed = 0.005;  // How fast the shape spins
 var isAutoRotating    = true;   // Whether auto-spin is on
 
@@ -467,6 +469,10 @@ async function loadGithubDashboard(username) {
       'https://api.github.com/users/' + encodeURIComponent(username) +
       '/events/public?per_page=25'
     );
+
+    // Save for theme toggle reload
+    lastFetchedEvents = events; 
+
     renderActivity(events.slice(0, 10));
 
     // --- Step 4: Show contributions chart ---
@@ -631,8 +637,9 @@ function showContributionsChart(username, events) {
     if (noteEl) noteEl.textContent = 'Approximate heatmap based on recent public activity.';
   };
 
-  // Set src last so the browser starts loading only after handlers are in place.
-  chartImg.src = 'https://ghchart.rshah.org/' + encodeURIComponent(username);
+// Set src last so the browser starts loading only after handlers are in place.
+var theme = document.documentElement.getAttribute('data-theme') || 'light';
+chartImg.src = 'https://kusa-image.deno.dev/' + encodeURIComponent(username) + '?theme=' + theme;
 
   // Safety net: if the browser resolved the image from cache synchronously
   // before onload could fire, manually trigger the appropriate handler.
@@ -689,6 +696,9 @@ function buildHeatmapFromEvents(events) {
 
   // GitHub-style green color palette: 0 events = light, max events = dark green
   var colors = ['#ebedf0', '#c6e48b', '#7bc96f', '#239a3b', '#196127'];
+  if (document.documentElement.getAttribute('data-theme') === 'dark') {
+    colors[0] = '#2d333b';
+}
 
   // Calculate grid dimensions
   var cellSize  = 10;


### PR DESCRIPTION
## What was broken
When dark mode was enabled, the contribution graph cells retained light mode colors. The background and text switched correctly, but the graph did not.

## Root cause
The project used ghchart.rshah.org to load the contribution graph as an external image. This service has no dark mode support and always returns a light-background image regardless of theme.

## Changes made
- Switched to kusa-image.deno.dev which supports a ?theme= URL parameter, enabling proper dark/light graph images
- Stored fetched events in a global variable so the chart reloads instantly on theme toggle without a new API call
- Kept the existing SVG fallback themed correctly for when the image fails to load
<img width="810" height="233" alt="Screenshot 2026-05-23 171823" src="https://github.com/user-attachments/assets/1a969357-5c79-4d49-9c67-de9dfa948dce" />

## Files changed
- script.js
- github.html

## How to test
1. Load the dashboard with any GitHub username
2. Toggle between dark and light mode
3. Confirm the contribution graph updates instantly with each toggle

Closes #878