### PR TITLE
fix: navbar font inconsistency when switching tabs (#858)

### DIFF
--- a/community.html
+++ b/community.html
@@ -19,10 +19,11 @@
         <ul class="nav-menu">
           <li><a class="nav-link" href="index.html">Home</a></li>
           <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
+          <li><a class="nav-link" href="community.html">Community Highlights</a></li>
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
     </nav>

--- a/contributions.html
+++ b/contributions.html
@@ -21,8 +21,9 @@
           <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
           <li><a class="nav-link" href="community.html">Community Highlights</a></li>
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
+          <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
     </nav>

--- a/explore.html
+++ b/explore.html
@@ -22,9 +22,10 @@
           <li><a class="nav-link" href="index.html">Home</a></li>
           <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
           <li><a class="nav-link" href="community.html">Community Highlights</a></li>
+          <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-      <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+      <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
 

--- a/github.html
+++ b/github.html
@@ -18,11 +18,12 @@
         </a>
         <ul class="nav-menu">
           <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
           <li><a class="nav-link" href="community.html">Community Highlights</a></li>
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
 

--- a/index.html
+++ b/index.html
@@ -30,12 +30,13 @@
           <img class="logo-img" src="assets/logo/thelogo.png" alt="XAYTHEON logo" />
         </a>
         <ul class="nav-menu">
+          <li><a class="nav-link" href="index.html">Home</a></li>
           <li><a class="nav-link" href="github.html">GitHub Dashboard</a></li>
           <li><a class="nav-link" href="community.html">Community Highlights</a></li>
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
     </nav>

--- a/style.css
+++ b/style.css
@@ -191,12 +191,15 @@ body.eightgon-page {
     display: flex;
     list-style: none;
     gap: 30px;
+    font-family: 'Researcher', 'OriginTech', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .nav-link {
     text-decoration: none;
     color: var(--text-color);
     font-weight: 500;
+    font-family: 'Researcher', 'OriginTech', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    letter-spacing: normal;
     transition: all 0.3s ease;
     position: relative;
 }

--- a/test_navbar_fix.js
+++ b/test_navbar_fix.js
@@ -1,0 +1,128 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * 单元测试：验证导航栏修复
+ * 测试项：
+ * 1. 所有页面导航栏链接一致
+ * 2. 导航栏CSS设置了固定字体
+ * 3. 没有CSS语法错误（important!）
+ */
+
+const PAGES = ['index.html', 'github.html', 'community.html', 'explore.html', 'contributions.html'];
+const EXPECTED_NAV_LINKS = [
+  'index.html',
+  'github.html',
+  'community.html',
+  'explore.html',
+  'contributions.html',
+];
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`✅ ${description}`);
+  } catch (err) {
+    console.error(`❌ ${description}`);
+    console.error(`   ${err.message}`);
+    process.exitCode = 1;
+  }
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg}\n  expected: ${expected}\n  actual:   ${actual}`);
+  }
+}
+
+function assertTrue(condition, msg) {
+  if (!condition) {
+    throw new Error(msg);
+  }
+}
+
+// 测试1：所有页面导航栏链接一致
+test('所有页面导航栏包含5个链接且顺序一致', () => {
+  for (const page of PAGES) {
+    const html = fs.readFileSync(path.join(__dirname, page), 'utf-8');
+    let navMatches = html.match(/class="nav-link"[^>]*href="([^"]+)"/g);
+    if (!navMatches || navMatches.length !== 5) {
+      // 再尝试另一种顺序
+      const altMatches = html.match(/href="([^"]+)"[^>]*class="nav-link"/g);
+      if (altMatches && altMatches.length === 5) {
+        navMatches = altMatches;
+      }
+    }
+    assertTrue(navMatches !== null, `${page}: 未找到导航栏链接`);
+    assertEqual(navMatches.length, 5, `${page}: 导航栏链接数量应为5个`);
+
+    const links = navMatches.map((m) => {
+      const match = m.match(/href="([^"]+)"/);
+      return match ? match[1] : null;
+    });
+
+    for (let i = 0; i < EXPECTED_NAV_LINKS.length; i++) {
+      assertEqual(
+        links[i],
+        EXPECTED_NAV_LINKS[i],
+        `${page}: 第${i + 1}个导航链接不匹配`
+      );
+    }
+  }
+});
+
+// 测试2：导航栏CSS设置了固定字体
+test('style.css为.nav-menu和.nav-link设置了固定字体', () => {
+  const css = fs.readFileSync(path.join(__dirname, 'style.css'), 'utf-8');
+  assertTrue(
+    css.includes("font-family: 'Researcher', 'OriginTech', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif"),
+    'style.css 中缺少导航栏固定字体设置'
+  );
+  assertTrue(
+    css.includes('letter-spacing: normal'),
+    'style.css 中缺少导航栏 letter-spacing: normal 设置'
+  );
+});
+
+// 测试3：没有CSS语法错误
+test('所有HTML文件中不存在 CSS important! 语法错误', () => {
+  for (const page of PAGES) {
+    const html = fs.readFileSync(path.join(__dirname, page), 'utf-8');
+    assertTrue(
+      !html.includes('important!'),
+      `${page}: 仍存在 CSS 语法错误 'important!'（应为 '!important'）`
+    );
+    assertTrue(
+      html.includes('!important'),
+      `${page}: 缺少 '!important' 关键字`
+    );
+  }
+});
+
+// 测试4：index.html 没有 eightgon-page 类（这是预期行为，子页面有）
+test('首页(index.html)不使用 eightgon-page 字体类', () => {
+  const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf-8');
+  assertTrue(
+    !html.includes('class="eightgon-page"'),
+    'index.html 不应包含 eightgon-page 类（这是设计意图）'
+  );
+});
+
+// 测试5：子页面仍保留 eightgon-page 类（用于页面正文内容字体）
+test('子页面保留 eightgon-page 类用于正文内容字体', () => {
+  const subPages = ['github.html', 'community.html', 'explore.html', 'contributions.html'];
+  for (const page of subPages) {
+    const html = fs.readFileSync(path.join(__dirname, page), 'utf-8');
+    assertTrue(
+      html.includes('class="eightgon-page"'),
+      `${page}: 应保留 eightgon-page 类以维持正文 Eightgon 字体风格`
+    );
+  }
+});
+
+console.log('\n📊 测试完成。');
+if (process.exitCode === 1) {
+  console.log('部分测试未通过，请检查修复。');
+} else {
+  console.log('全部测试通过！✨');
+}


### PR DESCRIPTION
## 修复内容

### Bug 描述
切换页面标签时，导航栏字体和间距发生明显变化（Issue #858）。

### 根因分析
- 首页  未使用  类 → 使用  字体
- 其他4个子页面均应用了  类 → 全局字体切换为  + 
- 导航栏  /  未显式指定字体，继承自 ，导致跨页字体不一致

### 修复方案
1. **style.css**: 为  和  显式设置  和 ，使导航栏字体不受页面级  影响
2. **5个HTML页面**: 统一导航栏链接（全部显示 Home / GitHub Dashboard / Community Highlights / Explore by Topic / Contributions），提升UX一致性
3. **CSS语法错误**: 将  修复为 

### 测试
新增  单元测试，验证：
- 所有页面导航栏链接一致（5个链接，顺序相同）
- CSS中导航栏字体已固定
- 不存在 CSS  语法错误
- 子页面保留  类（正文内容字体不受影响）

### 验证结果


Closes #858