### PR TITLE
Updated clear avatar feature

### DIFF
--- a/script.js
+++ b/script.js
@@ -419,6 +419,10 @@ function initGithubDashboard() {
     var noteEl = document.getElementById('gh-contrib-note');
     if (noteEl) noteEl.textContent = 'Enter a username and press Load Dashboard.';
 
+    // Clear the avatar image
+    var avatarEl = document.getElementById('gh-avatar');
+    if (avatarEl) avatarEl.src = 'assets/images/avatar-placeholder.png';
+
     setGithubStatus('Dashboard cleared.');
   });
 }


### PR DESCRIPTION
## 📝 Description

This PR fixes a bug in the GitHub Dashboard where the user profile image (avatar) was not clearing out.
Added logic to target the avatar image element inside the Clear button click event listener in script.js.
Now, when a user clicks the "Clear" button, the previous user's avatar is properly reset alongside all the text fields, instead of staying stuck on the screen.

## 🔗 Related Issue

#916 

Closes #

## 🏷️ Type of Change

<!-- Mark the relevant option with an "x" -->

- [ x] 🐛 Bug fix (non-breaking change that fixes an issue)


## 📸 Screenshots (if applicable)

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/e4dd1fde-a191-45e7-8644-b7c4fe9f799d" />

<img width="602" height="83" alt="image" src="https://github.com/user-attachments/assets/0eb3eedf-839a-4d2c-8a63-eb906b2170fa" />


## ✅ Checklist

<!-- Mark completed items with an "x" -->

- [x ] My code follows the project's style guidelines
- [ x] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ x] I have tested my changes locally


## 🧪 Testing

- Opened github.html and searched for a valid GitHub user. Verified that their profile text data and avatar image loaded perfectly.
- Clicked the "Clear" button.
- Verified that all fields successfully reset to defaults and the avatar image was completely cleared out.
- <!-- Describe how you tested your changes -->

- [ x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes

<!-- Any additional information for reviewers -->

---

**SWOC 2026 Participant?** Add `swoc2026` label to your PR! 🎉
