### PR TITLE
fix: improve calendar icon visibility in dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "xaytheon",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/style.css
+++ b/style.css
@@ -506,6 +506,17 @@ section {
     font-size: 0.95em;
 
 }
+/* Fix calendar icon visibility in dark mode */
+.github-form input[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+    cursor: pointer;
+    opacity: 1;
+}
+
+/* Improve dark mode support */
+[data-theme="dark"] .github-form input[type="date"] {
+    color-scheme: dark;
+}
 
 .github-form input:focus {
     border-color: var(--border-color);


### PR DESCRIPTION
## 📝 Description

Fixed the issue where the date picker calendar icon was not visible in dark mode on the GitHub Dashboard page.

The calendar icon blended into the dark background due to insufficient contrast. Added proper styling to improve icon visibility and maintain consistent dark mode appearance.

## 🔗 Related Issue

Closes #924

## 🏷️ Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] 🎨 Style/UI update

## 📸 Screenshots (if applicable)
### Before
<img width="1019" height="520" alt="Screenshot 2026-05-27 163340" src="https://github.com/user-attachments/assets/ed7b8dde-16ce-4be3-868a-da449056c035" />

* Calendar icon was dark/black and barely visible in dark mode.

### After
 Calendar icon is now clearly visible with improved contrast in dark mode.
 <img width="1819" height="900" alt="image" src="https://github.com/user-attachments/assets/f9b23d55-1a8d-4cf9-a57b-5706daef839e" />

## ✅ Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes locally
* [ ] Any dependent changes have been merged and published

## 🧪 Testing

* [x] Tested on Chrome
* [x] Tested on Firefox
* [ ] Tested on mobile
* [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes

Added CSS styling using `::-webkit-calendar-picker-indicator` and dark mode support for date input fields to improve accessibility and visibility.
