### PR TITLE
Change date reference from updated_at to pushed_at

### DIFF
--- a/script.js
+++ b/script.js
@@ -496,7 +496,7 @@ function filterReposByDate(repos) {
   if (!ghDateFilter.start && !ghDateFilter.end) return repos;
  
   return repos.filter(function(repo) {
-    var d = new Date(repo.updated_at || repo.pushed_at || repo.created_at);
+    var d = new Date(repo.pushed_at || repo.updated_at || repo.created_at);
     if (ghDateFilter.start && d < ghDateFilter.start) return false;
     if (ghDateFilter.end   && d > ghDateFilter.end)   return false;
     return true;
@@ -696,7 +696,7 @@ function renderRepos(repos) {
           '<span>★ ' + (repo.stargazers_count || 0) + '</span>' +
           '<span>⑂ ' + (repo.forks_count     || 0) + '</span>' +
           language +
-          '<span>Updated ' + timeAgo(repo.updated_at) + '</span>' +
+          '<span>Updated ' + timeAgo(repo.pushed_at || repo.updated_at) + '</span>'+
         '</div>' +
       '</div>';
   }


### PR DESCRIPTION
## 📝 Description

Fixed incorrect repository activity timestamps shown in the GitHub Dashboard.

Previously, repository cards displayed update times using updated_at, which reflects repository metadata changes (README updates, description edits, topic changes, etc.) rather than actual code activity.

This change prioritizes pushed_at when displaying repository update times and when filtering repositories by date, ensuring that the dashboard reflects real repository activity.

### Changes Made

* Updated repository filtering logic to use:

  *repo.pushed_at || repo.updated_at || repo.created_at*

* Updated repository cards to display:

  *timeAgo(repo.pushed_at || repo.updated_at)*

## 🏷️ Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
* [ ] 📝 Documentation update
* [ ] 🎨 Style/UI update
* [ ] ♻️ Code refactoring
* [ ] ⚡ Performance improvement
* [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

### Before

* Multiple repositories displayed misleading or identical "Updated X ago" timestamps.

### After

* Repository timestamps now reflect actual push activity and align more closely with GitHub repository activity.

## ✅ Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have tested my changes locally
* [ ] Any dependent changes have been merged and published

## 🧪 Testing

### Verification

* Confirmed repository cards now use repository push activity timestamps.

* Confirmed date filtering works correctly with the updated timestamp source.

* Verified repositories no longer display misleading identical update times.

* [x] Tested on Chrome

* [x] Tested on mobile

* [ ] Tested on Firefox

* [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes

This is a non-breaking fix that improves the accuracy of repository activity information displayed in the GitHub Dashboard.

---

**GSSoC 2026 Participant**
