### PR TITLE
feat: add meta descriptions and Open Graph tags for SEO

### DIFF
--- a/community.html
+++ b/community.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Community Highlights — XAYTHEON</title>
+  <meta name="description" content="Explore community highlights, discussions, collaborative initiatives, and social insights on Xaytheon.">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://debasmitabose0.github.io/xaytheon/community.html">
+  <meta property="og:title" content="Community Highlights — XAYTHEON">
+  <meta property="og:description" content="Explore community highlights, discussions, collaborative initiatives, and social insights on Xaytheon.">
+  <meta property="og:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://debasmitabose0.github.io/xaytheon/community.html">
+  <meta property="twitter:title" content="Community Highlights — XAYTHEON">
+  <meta property="twitter:description" content="Explore community highlights, discussions, collaborative initiatives, and social insights on Xaytheon.">
+  <meta property="twitter:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/contributions.html
+++ b/contributions.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contributions — XAYTHEON</title>
+  <meta name="description" content="Track, filter, and analyze developer contributions and activity metrics dynamically on Xaytheon.">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://debasmitabose0.github.io/xaytheon/contributions.html">
+  <meta property="og:title" content="Contributions — XAYTHEON">
+  <meta property="og:description" content="Track, filter, and analyze developer contributions and activity metrics dynamically on Xaytheon.">
+  <meta property="og:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://debasmitabose0.github.io/xaytheon/contributions.html">
+  <meta property="twitter:title" content="Contributions — XAYTHEON">
+  <meta property="twitter:description" content="Track, filter, and analyze developer contributions and activity metrics dynamically on Xaytheon.">
+  <meta property="twitter:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/explore.html
+++ b/explore.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Explore by Topic — XAYTHEON</title>
+  <meta name="description" content="Discover repositories, topics, and code connections through interactive 3D visualizations and network graphs on Xaytheon.">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://debasmitabose0.github.io/xaytheon/explore.html">
+  <meta property="og:title" content="Explore by Topic — XAYTHEON">
+  <meta property="og:description" content="Discover repositories, topics, and code connections through interactive 3D visualizations and network graphs on Xaytheon.">
+  <meta property="og:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://debasmitabose0.github.io/xaytheon/explore.html">
+  <meta property="twitter:title" content="Explore by Topic — XAYTHEON">
+  <meta property="twitter:description" content="Discover repositories, topics, and code connections through interactive 3D visualizations and network graphs on Xaytheon.">
+  <meta property="twitter:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
   <!-- D3.js: the library that draws the interactive force-directed graph -->

--- a/github.html
+++ b/github.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GitHub Dashboard — XAYTHEON</title>
+  <meta name="description" content="View GitHub repository comparisons, repository metrics, code activity, and developer profiles on the Xaytheon GitHub dashboard.">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://debasmitabose0.github.io/xaytheon/github.html">
+  <meta property="og:title" content="GitHub Dashboard — XAYTHEON">
+  <meta property="og:description" content="View GitHub repository comparisons, repository metrics, code activity, and developer profiles on the Xaytheon GitHub dashboard.">
+  <meta property="og:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://debasmitabose0.github.io/xaytheon/github.html">
+  <meta property="twitter:title" content="GitHub Dashboard — XAYTHEON">
+  <meta property="twitter:description" content="View GitHub repository comparisons, repository metrics, code activity, and developer profiles on the Xaytheon GitHub dashboard.">
+  <meta property="twitter:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,22 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>XAYTHEON - Collaborative Innovation Platform</title>
+  <meta name="description" content="XAYTHEON is a collaborative innovation platform featuring real-time GitHub integration, 3D interactive visualizations, repository analytics, and community-driven insights.">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://debasmitabose0.github.io/xaytheon/">
+  <meta property="og:title" content="XAYTHEON - Collaborative Innovation Platform">
+  <meta property="og:description" content="XAYTHEON is a collaborative innovation platform featuring real-time GitHub integration, 3D interactive visualizations, repository analytics, and community-driven insights.">
+  <meta property="og:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="https://debasmitabose0.github.io/xaytheon/">
+  <meta property="twitter:title" content="XAYTHEON - Collaborative Innovation Platform">
+  <meta property="twitter:description" content="XAYTHEON is a collaborative innovation platform featuring real-time GitHub integration, 3D interactive visualizations, repository analytics, and community-driven insights.">
+  <meta property="twitter:image" content="https://debasmitabose0.github.io/xaytheon/assets/og-image.png">
+
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
Closes #969 

# Summary
Injects descriptive SEO meta tags and Open Graph definitions into page heads.

# Changes Made
- Modified header section of `index.html`, `github.html`, `community.html`, `explore.html`, and `contributions.html`.

# Testing
- Visually checked head layout using local developer tools.
