### PR TITLE
fix: handle window resize for D3 force-directed graph SVG

### DIFF
--- a/explore.js
+++ b/explore.js
@@ -17,6 +17,21 @@ window.addEventListener("DOMContentLoaded", function () {
   var nodesById = {};
   var linksArray = [];
   var linkSet = {};
+  var currentSimulation = null;
+  var resizeTimer = null;
+
+  // Debounced resize handler to re-center the D3 force graph
+  window.addEventListener("resize", function () {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      if (currentSimulation) {
+        var w = svg.node().clientWidth;
+        var h = svg.node().clientHeight;
+        currentSimulation.force("center", d3.forceCenter(w / 2, h / 2));
+        currentSimulation.alpha(0.3).restart();
+      }
+    }, 250);
+  });
 
   function getThemeColor(variableName, fallback) {
     return getComputedStyle(document.documentElement)
@@ -150,7 +165,7 @@ window.addEventListener("DOMContentLoaded", function () {
       .attr("font-size", 10)
       .attr("fill", textColor);
 
-    d3.forceSimulation(nodesArray)
+    currentSimulation = d3.forceSimulation(nodesArray)
       .force(
         "charge",
         d3.forceManyBody().strength(function (d) {


### PR DESCRIPTION
Closes #977 

# Summary
Makes the interactive D3 force-directed graph on the Explore page fully responsive to window resize events.

# Changes Made
- Stored the D3 simulation reference in a outer-scoped variable.
- Added a debounced `resize` event listener in [explore.js](file:///e:/xaytheon/xaytheon/explore.js) to recalculate dimensions and update the force center smoothly.

# Testing
- Resized the browser window on the `/explore.html` page; verified the graph elements adapt and transition to the new center point automatically.
- Verified zero console warnings/errors on resize.

# Impact
Improves responsiveness and visual consistency of the network chart interface.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
