### PR TITLE
fix: prevent homepage content from displaying before loader completes (#772)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <canvas id="three-canvas"></canvas>
     <!-- Loading spinner shown while the 3D scene sets up -->
     <div id="loading-screen" class="loading-screen">
-      <div class="loader"></div>
+      <div id="loader"></div>
       <p>Initializing XAYTHEON...</p>
     </div>
   </div>
@@ -106,6 +106,24 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+    <script>
+  window.addEventListener('load', function () {
+    const loader = document.getElementById('loader');
+    const mainContent = document.getElementById('main-content');
+
+    if (loader) {
+      loader.style.opacity = '0';
+      loader.style.transition = 'opacity 0.4s ease';
+      setTimeout(function () {
+        loader.style.display = 'none';
+      }, 400);
+    }
+
+    if (mainContent) {
+      mainContent.style.visibility = 'visible';
+    }
+  });
+</script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ body.eightgon-page {
     backdrop-filter: blur(10px);
 }
 
-.loader {
+#loader {
     width: 50px;
     height: 50px;
     border: 3px solid rgba(0, 0, 0, 0.1);
@@ -119,6 +119,10 @@ body.eightgon-page {
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin-bottom: 20px;
+}
+
+#main-content {
+  visibility: hidden;    /* hidden until loader is gone */
 }
 
 @keyframes spin {


### PR DESCRIPTION
## 📝 Description

This PR fixes the issue where homepage content becomes visible behind the loader during the initial website load.

## 🔗 Related Issue

https://github.com/Saatvik-GT/xaytheon/issues/772
Closes #772

## 🏷️ Type of Change

<!-- Mark the relevant option with an "x" -->

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

N\A

## ✅ Checklist

<!-- Mark completed items with an "x" -->

- [x ] My code follows the project's style guidelines
- [ x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## 🧪 Testing

- [x ] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes
Verified that:

- Homepage content is hidden while the loader is displayed.

- Loader fades out after page load is complete.

- Homepage content becomes visible only after the loader is removed.

- No visual overlap occurs during initial loading

This change improves the initial loading experience by ensuring users only see the loader until the application is fully ready.

---

GSSoC'26
