### PR TITLE
fix: improve GitHub dashboard link styling and repository readability…

### DIFF
--- a/style.css
+++ b/style.css
@@ -968,3 +968,41 @@ section {
     padding: 8px 10px;
     font-size: 12px;
 }
+
+/* GitHub Dashboard - Dark Theme Repository & Link Styling */
+
+[data-theme="dark"] .repo-item {
+    background: #161b22;
+    border: 1px solid #30363d;
+}
+
+.repo-name a,
+.activity-item a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 600;
+    transition: color 0.2s ease;
+}
+
+.repo-name a:hover,
+.activity-item a:hover {
+    text-decoration: underline;
+}
+
+[data-theme="dark"] .repo-name a,
+[data-theme="dark"] .activity-item a {
+    color: #58a6ff;
+}
+
+[data-theme="light"] .repo-name a,
+[data-theme="light"] .activity-item a {
+    color: #0969da;
+}
+
+[data-theme="dark"] .repo-desc {
+    color: #c9d1d9;
+}
+
+[data-theme="dark"] .repo-meta {
+    color: #8b949e;
+}


### PR DESCRIPTION
## 📝 Description

This PR improves the visual consistency and readability of the GitHub Dashboard in Dark Theme.

### Changes Made
- Improved the appearance of repository cards in Dark Theme.
- Enhanced the readability of repository descriptions and metadata.
- Applied theme-aware styling to GitHub links in the **Top Repositories** and **Recent Activity** sections.
- Improved the overall visual consistency of the GitHub Dashboard while preserving the existing design.

## 🔗 Related Issue

Closes #1088

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 Style/UI update

## 📸 Screenshots (if applicable)

### Before
<img width="3024" height="1722" alt="image" src="https://github.com/user-attachments/assets/a5b11541-4bba-4776-9125-6c88a944c02f" />


### After
<img width="3024" height="1728" alt="image" src="https://github.com/user-attachments/assets/e1d21d9b-aa2e-45b9-a9f1-f54326d40e14" />

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## 🧪 Testing

- [x] Tested on Chrome
- [x] Tested on mobile

## 📋 Additional Notes

This PR focuses on improving the readability and visual consistency of the GitHub Dashboard in Dark Theme without affecting existing functionality.