### PR TITLE
fix: preserve theme toggle layout on responsive screens

### DIFF
--- a/github.html
+++ b/github.html
@@ -22,7 +22,7 @@
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary"></button>
 
       </div>
 

--- a/style.css
+++ b/style.css
@@ -250,11 +250,17 @@ body.eightgon-page {
 }
 
 #theme-toggle{
-    padding: 10px;
-    border-width: 1px;
-    border-radius: 100%;
+    width: 42px;
+    height: 42px;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
     background: none;
-    border-color: var(--border-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    cursor: pointer;
 }
 /* Hero Section */
 .hero {


### PR DESCRIPTION
## 📝 Description

This PR fixes the responsive layout issue affecting the theme toggle button on the GitHub Dashboard.

### Changes Made
- Fixed the theme toggle button stretching on smaller screen sizes.
- Updated the toggle button styling to maintain a consistent circular shape.
- Removed invalid inline CSS from the theme toggle button.
- Improved the responsiveness and alignment of the navbar while preserving existing functionality.

## 🔗 Related Issue

Closes #1089

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 Style/UI update
- [ ] 
## 📸 Screenshots (if applicable)

### Before
<img width="1854" height="1720" alt="image" src="https://github.com/user-attachments/assets/b57a53a6-e171-423d-a060-6630e78eb0fc" />

### After
<img width="1850" height="1734" alt="image" src="https://github.com/user-attachments/assets/429af7ef-d7a3-4d37-881c-8bed12e64a8f" />

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes locally

## 🧪 Testing

- [x] Tested on Chrome
- [x] Tested on mobile (Chrome DevTools Responsive Mode)

## 📋 Additional Notes

The fix ensures that the theme toggle button retains its intended circular appearance and remains properly aligned across different viewport sizes without affecting existing functionality.