### PR TITLE
fix: define injectContribDateFilterBar to prevent initialization error

### DIFF
--- a/contributions.js
+++ b/contributions.js
@@ -103,6 +103,8 @@ function injectDateFilterStyles() {
   ].join('\n');
   document.head.appendChild(style);
 }
+
+function injectContribDateFilterBar() {
   var listEl = document.getElementById('contrib-list');
   if (!listEl) return;
 
@@ -223,6 +225,7 @@ function injectDateFilterStyles() {
     document.getElementById('contrib-custom-range').style.display = 'none';
     renderContributions();
   });
+}
 
 function updateContribBadge(start, end) {
   var badge    = document.getElementById('contrib-filter-badge');


### PR DESCRIPTION
Fixes #1055

## Description

This PR fixes the initialization error on the Contributions page by defining the missing `injectContribDateFilterBar()` function and wrapping the existing contribution date filter initialization logic inside it.

### Changes Made

- Added the missing `injectContribDateFilterBar()` function declaration.
- Wrapped the existing contribution date filter initialization logic.
- Preserved the existing filtering behavior.

### Testing

- Verified the Contributions page loads without console errors.
- Verified the contribution date filter bar renders correctly.
- Verified contribution filtering continues to work as expected.