### PR TITLE
fix(login): close form tag, fix DOM structure, and remove stray body comment

### DIFF
--- a/login.html
+++ b/login.html
@@ -431,10 +431,11 @@
         </div>
         
         <div style="text-align: right; margin-top: -8px;">
-  <a href="forgot-password.html" style="color: var(--link-color); text-decoration: none; font-size: 0.9em;">
-    Forgot password?
-  </a>
-</div>
+          <a href="forgot-password.html"
+             style="color: var(--link-color); text-decoration: none; font-size: 0.9em;">
+            Forgot password?
+          </a>
+        </div>
 
         <button type="submit" class="btn"
           style="width: 100%; margin-top: 24px; background: var(--text-primary); color: var(--bg-primary); font-weight: 600;"
@@ -461,6 +462,7 @@
         <div class="center muted" style="margin-top: 24px; font-size: 0.85em;">
           Authentication is handled securely by the Xaytheon backend.
         </div>
+      </form>
     </div>
   </div>
 
@@ -528,8 +530,6 @@
       </div>
     </div>
   </div>
-
-  /* Moved to head styles */
 
   <!-- Inline JS -->
   <script>


### PR DESCRIPTION
## Summary

This PR fixes the HTML structure of the login page by:

- Adding the missing closing `</form>` tag inside `.auth-card`
- Removing the stray `/* Moved to head styles */` text rendered in the page body
- Normalizing the indentation of the forgot-password section for better readability

## Testing

- Verified the login page renders correctly
- Confirmed the login form structure is valid
- Ensured the stray text no longer appears on the page
- Verified the login form remains functional

Closes #1062

##SS
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5265d553-a093-414e-9706-1782dfaf83d3" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f9f78f16-d6f5-468c-95d1-8ec6d3aff9f1" />
