### PR TITLE
feat(compare): prevent users from comparing a GitHub profile with itself

### DIFF
--- a/script.js
+++ b/script.js
@@ -1204,14 +1204,28 @@ function injectCompareUI() {
   });
 
   // ── Wire compare button ──
-  document.getElementById('gh-compare-btn').addEventListener('click', function() {
-    var u1 = (document.getElementById('gh-username').value || '').trim();
-    var u2 = (document.getElementById('gh-compare-username').value || '').trim();
-    if (!u1) { alert('Please load a primary profile first.'); return; }
-    if (!u2) { alert('Please enter a username to compare with.'); return; }
-    runComparison(u1, u2);
-  });
+  document.getElementById('gh-compare-btn').addEventListener('click', function () {
+  var u1 = (document.getElementById('gh-username').value || '').trim();
+  var u2 = (document.getElementById('gh-compare-username').value || '').trim();
 
+  if (!u1) {
+    alert('Please load a primary profile first.');
+    return;
+  }
+
+  if (!u2) {
+    alert('Please enter a username to compare with.');
+    return;
+  }
+
+  // Prevent comparing the same GitHub profile
+  if (u1.toLowerCase() === u2.toLowerCase()) {
+    alert('Please enter a different GitHub username to compare.');
+    return;
+  }
+
+  runComparison(u1, u2);
+});
   // Also allow Enter key in the compare input
   document.getElementById('gh-compare-username').addEventListener('keydown', function(e) {
     if (e.key === 'Enter') document.getElementById('gh-compare-btn').click();

--- a/script.js
+++ b/script.js
@@ -599,7 +599,10 @@ function initGithubDashboard() {
       if (customRange) customRange.style.display = 'none';
       updateFilterBadge(null, null);
     }
-
+    var avatarEl = document.getElementById('gh-avatar');
+    if (avatarEl) {
+      avatarEl.removeAttribute('src');
+    }
     setGithubStatus('Dashboard cleared.');
   });
 }


### PR DESCRIPTION
## Summary

This PR prevents users from comparing a GitHub profile with itself.

### Changes
- Added validation to prevent comparing identical GitHub usernames.
- Validation is case-insensitive.
- Ignores leading and trailing spaces using `trim()`.
- Displays a user-friendly validation message.
- Prevents unnecessary comparison requests.

### Testing
- ✅ `gayatripadalia` vs `gayatripadalia` → Validation shown.
- ✅ `gayatripadalia` vs ` Gayatripadalia ` → Validation shown.
- ✅ `gaearon` vs `torvalds` → Comparison works normally.

Closes #933

## gayatripadalia vs gayatripadalia

<img width="1920" height="1200" alt="Screenshot (1345)" src="https://github.com/user-attachments/assets/f61b81ff-385a-4c2e-befe-43c2409060a2" />

## gaearon vs torvalds

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/18385b94-6d5f-4335-b75d-5cc854c73821" />




