### PR TITLE
feat: add copy-to-clipboard for repository, profile and contribution links

### DIFF
--- a/login.html
+++ b/login.html
@@ -431,10 +431,11 @@
         </div>
         
         <div style="text-align: right; margin-top: -8px;">
-  <a href="forgot-password.html" style="color: var(--link-color); text-decoration: none; font-size: 0.9em;">
-    Forgot password?
-  </a>
-</div>
+          <a href="forgot-password.html"
+             style="color: var(--link-color); text-decoration: none; font-size: 0.9em;">
+            Forgot password?
+          </a>
+        </div>
 
         <button type="submit" class="btn"
           style="width: 100%; margin-top: 24px; background: var(--text-primary); color: var(--bg-primary); font-weight: 600;"
@@ -461,6 +462,7 @@
         <div class="center muted" style="margin-top: 24px; font-size: 0.85em;">
           Authentication is handled securely by the Xaytheon backend.
         </div>
+      </form>
     </div>
   </div>
 
@@ -528,8 +530,6 @@
       </div>
     </div>
   </div>
-
-  /* Moved to head styles */
 
   <!-- Inline JS -->
   <script>

--- a/script.js
+++ b/script.js
@@ -1234,14 +1234,28 @@ function injectCompareUI() {
   });
 
   // ── Wire compare button ──
-  document.getElementById('gh-compare-btn').addEventListener('click', function() {
-    var u1 = (document.getElementById('gh-username').value || '').trim();
-    var u2 = (document.getElementById('gh-compare-username').value || '').trim();
-    if (!u1) { alert('Please load a primary profile first.'); return; }
-    if (!u2) { alert('Please enter a username to compare with.'); return; }
-    runComparison(u1, u2);
-  });
+  document.getElementById('gh-compare-btn').addEventListener('click', function () {
+  var u1 = (document.getElementById('gh-username').value || '').trim();
+  var u2 = (document.getElementById('gh-compare-username').value || '').trim();
 
+  if (!u1) {
+    alert('Please load a primary profile first.');
+    return;
+  }
+
+  if (!u2) {
+    alert('Please enter a username to compare with.');
+    return;
+  }
+
+  // Prevent comparing the same GitHub profile
+  if (u1.toLowerCase() === u2.toLowerCase()) {
+    alert('Please enter a different GitHub username to compare.');
+    return;
+  }
+
+  runComparison(u1, u2);
+});
   // Also allow Enter key in the compare input
   document.getElementById('gh-compare-username').addEventListener('keydown', function(e) {
     if (e.key === 'Enter') document.getElementById('gh-compare-btn').click();

--- a/script.js
+++ b/script.js
@@ -600,7 +600,10 @@ function initGithubDashboard() {
       if (customRange) customRange.style.display = 'none';
       updateFilterBadge(null, null);
     }
-
+    var avatarEl = document.getElementById('gh-avatar');
+    if (avatarEl) {
+      avatarEl.removeAttribute('src');
+    }
     setGithubStatus('Dashboard cleared.');
   });
 }

--- a/script.js
+++ b/script.js
@@ -600,10 +600,7 @@ function initGithubDashboard() {
       if (customRange) customRange.style.display = 'none';
       updateFilterBadge(null, null);
     }
-    var avatarEl = document.getElementById('gh-avatar');
-    if (avatarEl) {
-      avatarEl.removeAttribute('src');
-    }
+
     setGithubStatus('Dashboard cleared.');
   });
 }
@@ -806,9 +803,13 @@ function showContributionsChart(username, events) {
     var btn = document.createElement("button");
     btn.innerHTML = "📋";
     btn.className = "copy-btn";
-
+    // GitHub doesn't provide a dedicated public contributions page.
+    // A user's contribution history is displayed on their GitHub profile,
+    // including contributions across their own repositories and repositories
+    // where they've contributed via issues or pull requests.
+    // Therefore, we copy the profile URL instead.
     btn.onclick = function () {
-        copyLink("https://github.com/users/" + username + "/contributions");
+        copyLink("https://github.com/users/" + username);
     };
 
     container.appendChild(btn);
@@ -1234,28 +1235,14 @@ function injectCompareUI() {
   });
 
   // ── Wire compare button ──
-  document.getElementById('gh-compare-btn').addEventListener('click', function () {
-  var u1 = (document.getElementById('gh-username').value || '').trim();
-  var u2 = (document.getElementById('gh-compare-username').value || '').trim();
+  document.getElementById('gh-compare-btn').addEventListener('click', function() {
+    var u1 = (document.getElementById('gh-username').value || '').trim();
+    var u2 = (document.getElementById('gh-compare-username').value || '').trim();
+    if (!u1) { alert('Please load a primary profile first.'); return; }
+    if (!u2) { alert('Please enter a username to compare with.'); return; }
+    runComparison(u1, u2);
+  });
 
-  if (!u1) {
-    alert('Please load a primary profile first.');
-    return;
-  }
-
-  if (!u2) {
-    alert('Please enter a username to compare with.');
-    return;
-  }
-
-  // Prevent comparing the same GitHub profile
-  if (u1.toLowerCase() === u2.toLowerCase()) {
-    alert('Please enter a different GitHub username to compare.');
-    return;
-  }
-
-  runComparison(u1, u2);
-});
   // Also allow Enter key in the compare input
   document.getElementById('gh-compare-username').addEventListener('keydown', function(e) {
     if (e.key === 'Enter') document.getElementById('gh-compare-btn').click();


### PR DESCRIPTION
## Description
Added copy-to-clipboard functionality for:
- Repository links
- GitHub profile link
- Contribution link

A success message is shown after copying.

## Related Issue
Closes #884

## Type of Change
- [x] New feature

## Testing
- [x] Tested locally
- [x] Verified all links copy correctly

## SS

<img width="1920" height="1200" alt="Screenshot (1355)" src="https://github.com/user-attachments/assets/c26443dd-390b-4064-a93f-b5efb67ba678" />

<img width="1920" height="1200" alt="Screenshot (1356)" src="https://github.com/user-attachments/assets/ae6df331-143e-4996-8917-2fdd61868d54" />

<img width="1920" height="1200" alt="Screenshot (1357)" src="https://github.com/user-attachments/assets/ef965b9f-ee54-4b9b-810b-19f9fc79d539" />