### PR TITLE
Fix invalid CSS syntax for theme toggle button in github.html

### DIFF
--- a/github.html
+++ b/github.html
@@ -22,7 +22,7 @@
           <li><a class="nav-link" href="explore.html">Explore by Topic</a></li>
           <li><a class="nav-link" href="contributions.html">Contributions</a></li>
         </ul>
-        <button id="theme-toggle" class="btn btn-primary" style="margin:0px important!"></button>
+        <button id="theme-toggle" class="btn btn-primary" style="margin:0px !important"></button>
 
       </div>
 


### PR DESCRIPTION
Corrected the inline CSS syntax for the theme toggle button by replacing `important!` with the valid `!important` declaration for the `margin` property.
