### PR TITLE
fix: clear GitHub profile avatar on dashboard reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -600,6 +600,9 @@ function initGithubDashboard() {
     setHtml('gh-activity-list','');
     setHtml('gh-contrib-svg',  '');
 
+    var avatarEl = document.getElementById('gh-avatar');
+    if (avatarEl) avatarEl.removeAttribute('src');
+
     var noteEl = document.getElementById('gh-contrib-note');
     if (noteEl) noteEl.textContent = 'Enter a username and press Load Dashboard.';
 


### PR DESCRIPTION
## Related Issue

Fixes #1051

## Summary

This PR fixes a UI inconsistency in the GitHub Dashboard where the profile avatar remained visible after clicking the **Clear** button.

## Changes Made

- Clear the `gh-avatar` image source when resetting the dashboard.
- Keep the change scoped only to the dashboard reset logic.

## Files Changed

- `script.js`

## Testing

- Loaded a GitHub profile successfully.
- Verified the avatar is displayed.
- Clicked **Clear**.
- Confirmed the avatar is removed along with the other profile information.
- Verified no regressions in dashboard functionality.