### PR TITLE
fix: validate invalid custom date inputs in date range filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -392,6 +392,7 @@ function injectDateFilterBar() {
     '    <label>To</label>',
     '    <input type="date" id="gh-date-end" style="border:1px solid ' + borderColor + ';background:' + bgColor + ';color:' + textColor + '" />',
     '  </div>',
+    '  <div id="gh-date-error" style="display:none;color:#ef4444;font-size:12px;width:100%;margin-top:4px;"></div>',
     '  <button class="xf-apply" id="gh-date-apply">Apply</button>',
     '</div>',
   ].join('\n');
@@ -443,7 +444,19 @@ function injectDateFilterBar() {
   document.getElementById('gh-date-apply').addEventListener('click', function() {
     var startVal = document.getElementById('gh-date-start').value;
     var endVal   = document.getElementById('gh-date-end').value;
- 
+
+    var startInput = document.getElementById('gh-date-start');
+    var endInput = document.getElementById('gh-date-end');
+    var errorMsg = document.getElementById('gh-date-error');
+
+    errorMsg.style.display = 'none';
+
+    if (startInput.matches(":invalid") || endInput.matches(":invalid")) {
+      errorMsg.textContent = "Please enter a valid calendar date.";
+      errorMsg.style.display = "block";
+      return;
+    }
+
     if (!startVal && !endVal) {
       ghDateFilter = { start: null, end: null };
       updateFilterBadge(null, null);
@@ -518,7 +531,7 @@ function filterReposByDate(repos) {
     return true;
   });
 }
- 
+
 /** Re-render dashboard cards using cached data + current filter */
 function applyDateFilterAndRender() {
   if (!lastFetchedEvents && !lastFetchedRepos) return;


### PR DESCRIPTION
## 📝 Description

This PR fixes the custom date range validation in the GitHub Dashboard.

Previously, invalid calendar dates (e.g. `31-02-2025`) were accepted and the filter was applied without notifying the user.

### Changes made
- Added validation for invalid calendar dates in the custom date range filter.
- Displays an inline validation message when an invalid date is entered.
- Prevents the filter from being applied until valid dates are provided.
- Preserves the existing start date/end date validation.

## 🔗 Related Issue

Closes #1137

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## 📸 Screenshots (if applicable)

Not included.

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## 🧪 Testing

- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

### Test Cases
- ✅ Invalid "From" date displays the validation message.
- ✅ Invalid "To" date displays the validation message.
- ✅ Valid dates apply the filter successfully.
- ✅ Existing "Start date must be before end date" validation still works.

## 📋 Additional Notes

This change only affects the custom date range filter and does not modify any other dashboard functionality.