### PR TITLE
docs: fix duplicate section numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Features:
 
 **Purpose**: Helps developers stay current with what's hot in the open-source world and discover popular projects in their areas of interest.
 
-### 4. **Explore by Topic** (explore.html)
+### 5. **Explore by Topic** (explore.html)
 **Advanced Repository Discovery & Mapping**
 
 Features:
@@ -268,7 +268,7 @@ Features:
 
 **Purpose**: Enables deep exploration of the GitHub ecosystem, helping you discover repositories through topic relationships and technology connections.
 
-### 5. **Your Open Source Contributions** (contributions.html)
+### 6. **Your Open Source Contributions** (contributions.html)
 **Personal Contribution Tracker**
 
 Features:


### PR DESCRIPTION
## 📝 Description
Fixed duplicate section numbering in README.md — two sections were both numbered "4.", causing the subsequent sections to be off by one.

## 🔗 Related Issue
Closes #None (just a documentation quick fix )

## 🏷️ Type of Change
- [x] 📝 Documentation update

## 📸 Screenshots (if applicable)
N/A — documentation-only fix.

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [ ] Any dependent changes have been merged and published

## 🧪 Testing
- [ ] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)

## 📋 Additional Notes
Simple renumbering fix, no functional changes.

---
**SWOC 2026 Participant?** Add `swoc2026` label to your PR! 🎉