### PR TITLE
feat(a11y): add keyboard shortcuts system with help modal

### DIFF
--- a/community.html
+++ b/community.html
@@ -124,5 +124,21 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/contributions.html
+++ b/contributions.html
@@ -123,5 +123,21 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/explore.html
+++ b/explore.html
@@ -124,5 +124,21 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/github.html
+++ b/github.html
@@ -164,5 +164,21 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -107,5 +107,21 @@
     }
   </script>
 
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -724,5 +724,21 @@ function getAuthErrorMessage(error) {
   </script>
   <script src="theme.js?v=1.0.0"></script>
 <div id="footer-placeholder"></div>
+
+<!-- Keyboard Shortcuts Modal -->
+<div id="shortcuts-modal" class="shortcuts-modal" aria-hidden="true" role="dialog" aria-label="Keyboard shortcuts">
+  <div class="shortcuts-modal__content">
+    <div class="shortcuts-modal__header">
+      <h3>Keyboard Shortcuts</h3>
+      <button class="shortcuts-modal__close" aria-label="Close">&times;</button>
+    </div>
+    <div class="shortcuts-modal__body">
+      <div class="shortcut-row"><kbd>?</kbd><span>Open this help</span></div>
+      <div class="shortcut-row"><kbd>/</kbd><span>Focus search input</span></div>
+      <div class="shortcut-row"><kbd>Esc</kbd><span>Close modal / dropdown</span></div>
+    </div>
+  </div>
+</div>
+<script src="shortcuts.js"></script>
 </body>
 </html>

--- a/shortcuts.js
+++ b/shortcuts.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict';
+  var modal = null;
+  function getModal() { if (modal) return modal; modal = document.getElementById('shortcuts-modal'); return modal; }
+  function openModal() { var m = getModal(); if (m) { m.classList.add('shortcuts-modal--visible'); m.setAttribute('aria-hidden', 'false'); var c = m.querySelector('.shortcuts-modal__close'); if (c) c.focus(); } }
+  function closeModal() { var m = getModal(); if (m) { m.classList.remove('shortcuts-modal--visible'); m.setAttribute('aria-hidden', 'true'); } }
+  function isModalOpen() { var m = getModal(); return m && m.classList.contains('shortcuts-modal--visible'); }
+  function isInputFocused() { var el = document.activeElement; if (!el) return false; var t = el.tagName.toLowerCase(); return t === 'input' || t === 'textarea' || t === 'select' || el.isContentEditable; }
+  function getSearchInput() { var ids = ['gh-username','trend-lang','trend-topic','ex-base-topic','ex-language','cf-project']; for (var i=0;i<ids.length;i++) { var el = document.getElementById(ids[i]); if (el) return el; } var f = document.querySelector('form'); if (f) return f.querySelector('input[type="text"]'); return null; }
+  function handleKeydown(e) { if (isInputFocused()) { if (e.key==='Escape') e.target.blur(); return; } switch(e.key) { case '?': e.preventDefault(); isModalOpen()?closeModal():openModal(); break; case '/': e.preventDefault(); var s=getSearchInput(); if(s) s.focus(); break; case 'Escape': if(isModalOpen()){e.preventDefault();closeModal();} var dd=document.querySelectorAll('.user-dropdown:not([hidden])'); for(var i=0;i<dd.length;i++) dd[i].setAttribute('hidden',''); break; } }
+  function init() { document.addEventListener('keydown',handleKeydown); document.addEventListener('click',function(e){if(isModalOpen()&&e.target.classList.contains('shortcuts-modal'))closeModal();}); var c=document.querySelector('.shortcuts-modal__close'); if(c) c.addEventListener('click',closeModal); }
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',init); else init();
+  window.XAYTHEON_SHORTCUTS={open:openModal,close:closeModal};
+})();

--- a/style.css
+++ b/style.css
@@ -980,3 +980,15 @@ section {
 .copy-btn:hover{
     opacity:0.7;
 }
+/* Keyboard Shortcuts Modal */
+.shortcuts-modal { display:none; position:fixed; inset:0; z-index:9999; background:rgba(0,0,0,0.5); backdrop-filter:blur(4px); justify-content:center; align-items:center; }
+.shortcuts-modal--visible { display:flex; }
+.shortcuts-modal__content { background:var(--card-color,#fff); color:var(--text-color,#000); border-radius:16px; max-width:420px; width:90%; box-shadow:0 20px 60px rgba(0,0,0,0.3); overflow:hidden; }
+.shortcuts-modal__header { display:flex; justify-content:space-between; align-items:center; padding:16px 20px; border-bottom:1px solid rgba(128,128,128,0.2); }
+.shortcuts-modal__header h3 { margin:0; font-size:1.1em; }
+.shortcuts-modal__close { background:none; border:none; font-size:24px; cursor:pointer; color:var(--text-color,#000); padding:4px 8px; border-radius:6px; }
+.shortcuts-modal__close:hover { background:rgba(128,128,128,0.15); }
+.shortcuts-modal__body { padding:20px; }
+.shortcut-row { display:flex; align-items:center; gap:14px; padding:10px 0; border-bottom:1px solid rgba(128,128,128,0.1); }
+.shortcut-row:last-child { border-bottom:none; }
+.shortcut-row kbd { display:inline-flex; align-items:center; justify-content:center; min-width:32px; height:28px; padding:0 8px; background:rgba(128,128,128,0.12); border:1px solid rgba(128,128,128,0.25); border-radius:6px; font-size:13px; font-weight:700; }


### PR DESCRIPTION
## What
Adds keyboard shortcuts: ? opens help modal, / focuses search, Esc closes overlays.

## Why
Improves power-user workflow and accessibility for keyboard navigation.

## Changes
- Created reusable shortcuts.js module
- Added shortcuts help modal HTML/CSS
- Added ARIA attributes and focus management

## Testing
1. Press ? - help modal opens
2. Press / - search input focuses
3. Press Esc - modal closes