### PR TITLE
feat(theme): auto-detect OS color scheme on first visit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<script>
+(function(){
+var saved=localStorage.getItem('xaytheon:theme');
+if(!saved){if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.setAttribute('data-theme','dark');else document.documentElement.setAttribute('data-theme','light');}
+if(window.matchMedia){window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change',function(e){if(!localStorage.getItem('xaytheon:theme'))document.documentElement.setAttribute('data-theme',e.matches?'dark':'light');});}
+})();
+</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>XAYTHEON - Collaborative Innovation Platform</title>


### PR DESCRIPTION
## What
Auto-detects OS color scheme on first visit instead of defaulting to light.

## Why
Respects user's system preference from the first visit.

## Changes
- Added OS detection via prefers-color-scheme
- Listens for OS theme changes
- Only applies when no saved preference