### PR TITLE
feat(notifications): add browser notification support for activity

### DIFF
--- a/community.html
+++ b/community.html
@@ -124,5 +124,6 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/contributions.html
+++ b/contributions.html
@@ -123,5 +123,6 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/explore.html
+++ b/explore.html
@@ -124,5 +124,6 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/github.html
+++ b/github.html
@@ -164,5 +164,6 @@
         toggleBtn.innerHTML = theme === 'dark' ? '☀️' : '🌙';
     }
     </script>
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -107,5 +107,6 @@
     }
   </script>
 
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -724,5 +724,6 @@ function getAuthErrorMessage(error) {
   </script>
   <script src="theme.js?v=1.0.0"></script>
 <div id="footer-placeholder"></div>
+<script src="notifications.js"></script>
 </body>
 </html>

--- a/notifications.js
+++ b/notifications.js
@@ -1,0 +1,9 @@
+(function(){
+'use strict';
+var lastCount=0,granted=false;
+function requestPerm(){if(!('Notification' in window))return;if(Notification.permission==='granted'){granted=true;return;}if(Notification.permission!=='denied')Notification.requestPermission().then(function(p){granted=p==='granted';});}
+function send(title,body){if(!granted||Notification.permission!=='granted')return;try{var n=new Notification(title,{body:body,tag:'xaytheon-activity',renotify:true});n.onclick=function(){window.focus();n.close();};setTimeout(function(){n.close();},5000);}catch(e){}}
+function checkActivity(events){if(!events||!granted)return;if(lastCount>0&&events.length>lastCount)send('New GitHub Activity','You have '+(events.length-lastCount)+' new event(s).');lastCount=events.length;}
+document.addEventListener('click',function h(){requestPerm();document.removeEventListener('click',h);});
+window.XAYTHEON_NOTIFICATIONS={request:requestPerm,send:send,checkActivity:checkActivity};
+})();


### PR DESCRIPTION
## What
Sends browser notifications when new GitHub activity is detected.

## Why
Alerts users to new activity without checking the page.

## Changes
- Created notifications.js module
- Requests permission on user interaction
- Sends notification on new activity